### PR TITLE
Update Agent Prompts to Respect Vacation Mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,12 @@ As an agent interacting with Mecris, these are your core operational directives.
 - 30-minute cap per task segment.
 - Use `Skill(tdg:atomic)` after coding sessions.
 
-### 🐕 THE HIGHEST PRIORITY: ACTIVITY & DOGGIES
+### 🐕 THE HIGHEST PRIORITY: PHYSICAL ACTIVITY
 **Every session: Prioritize physical activity, then technical work.**
-1. Check `get_narrator_context`.
-2. If `vacation_mode` is true and walk is needed, remind the user: "🏃 Priority: Log your personal activity!"
-3. If `vacation_mode` is false and walk is needed, remind the user: "🐾 Priority: Walk Boris & Fiona first!"
+1. Check the `daily_walk_status` and `recommendations` array in `get_narrator_context`.
+2. If activity is needed, it is your job to ensure it happens. You are the accountability coach.
+3. Use your own voice and agency to deliver the reminder. Feel free to drop it in the conversation somewhere—beginning, middle, or end—where it seems appropriate and isn't likely to be missed.
+4. Adapt to the context provided. If the context explicitly mentions Boris and Fiona, use them as motivation! If the context is strictly focused on personal activity (e.g., they are away), keep the focus on the user hitting their physical goals. Keep it natural, and avoid mentioning the dogs multiple times in a single exchange if there are many other things to focus on.
 
 ### 🧠 Your Key Operational Directives
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -27,11 +27,12 @@ As an agent interacting with Mecris, these are your core operational directives.
 - 30-minute cap per task segment.
 - Use `Skill(tdg:atomic)` after coding sessions.
 
-### 🐕 THE HIGHEST PRIORITY: ACTIVITY & DOGGIES
+### 🐕 THE HIGHEST PRIORITY: PHYSICAL ACTIVITY
 **Every session: Prioritize physical activity, then technical work.**
-1. Check `get_narrator_context`.
-2. If `vacation_mode` is true and walk is needed, remind the user: "🏃 Priority: Log your personal activity!"
-3. If `vacation_mode` is false and walk is needed, remind the user: "🐾 Priority: Walk Boris & Fiona first!"
+1. Check the `daily_walk_status` and `recommendations` array in `get_narrator_context`.
+2. If activity is needed, it is your job to ensure it happens. You are the accountability coach.
+3. Use your own voice and agency to deliver the reminder. Feel free to drop it in the conversation somewhere—beginning, middle, or end—where it seems appropriate and isn't likely to be missed.
+4. Adapt to the context provided. If the context explicitly mentions Boris and Fiona, use them as motivation! If the context is strictly focused on personal activity (e.g., they are away), keep the focus on the user hitting their physical goals. Keep it natural, and avoid mentioning the dogs multiple times in a single exchange if there are many other things to focus on.
 
 ### 🧠 Your Key Operational Directives
 


### PR DESCRIPTION
This PR updates the system prompts (`GEMINI.md` and `CLAUDE.md`) to explicitly instruct the AI agents to check the `vacation_mode` flag in the `get_narrator_context` payload. 

When `vacation_mode` is true, the agents will correctly substitute the "Walk Boris & Fiona" startup greeting with a generic "Log your personal activity!" greeting, ensuring that the conversational tone matches the user's current situation without referencing the doggies when they are away.