### PR TITLE
CHORE: Relocate large model and binary files (#104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ htmlcov/
 /servers
 /servers/**
 tools/talktype/talktype_whisper_server.pid
+
+# Large Models
+.models/

--- a/scripts/setup_models.sh
+++ b/scripts/setup_models.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# setup_models.sh
+# Restores large model files and binaries to their original locations from the .models/ directory.
+# If they are not found in .models/, instructions are provided on where to download them.
+
+set -e
+
+echo "Restoring models from .models/..."
+
+if [ -d ".models/echokit/gsv_tts/resources" ]; then
+    echo "Found gsv_tts resources. Restoring..."
+    mkdir -p tools/echokit/gsv_tts/resources
+    cp -r .models/echokit/gsv_tts/resources/* tools/echokit/gsv_tts/resources/
+else
+    echo "WARNING: .models/echokit/gsv_tts/resources not found."
+    echo "Please download the required .pt files and place them in tools/echokit/gsv_tts/resources/"
+fi
+
+if [ -d ".models/echokit/libtorch/lib" ]; then
+    echo "Found libtorch libraries. Restoring..."
+    mkdir -p tools/echokit/libtorch/lib
+    cp -r .models/echokit/libtorch/lib/* tools/echokit/libtorch/lib/
+else
+    echo "WARNING: .models/echokit/libtorch/lib not found."
+    echo "Please download the libtorch libraries and place them in tools/echokit/libtorch/lib/"
+fi
+
+echo "Model setup complete."


### PR DESCRIPTION
Large binary files (ML models and libraries) in the root search path are hindering repository operations like `grep` and `git status`.

This PR:
1. Adds `.models/` to `.gitignore`.
2. Creates `scripts/setup_models.sh` to restore them if needed for local development.

Closes #104