### PR TITLE
FEATURE: Autonomous Spin Cron Trigger (#100)

### DIFF
--- a/mecris-go-spin/sync-service/spin.toml
+++ b/mecris-go-spin/sync-service/spin.toml
@@ -18,11 +18,10 @@ clozemaster_password = { required = false, default = "" }
 route = "/..."
 component = "sync-service"
 
-# [[trigger.cron]]
-# component = "sync-service"
-# cron_expression = "0 0 */2 * * *"
-# NOTE: Cron is temporarily disabled to avoid masking issues in the main framework.
-# It should only be re-enabled once the MCP leader can coordinate these events.
+[[trigger.cron]]
+component = "sync-service"
+cron_expression = "0 0 */2 * * *"
+# Cron enabled to support Autonomous Failover (Issue #100)
 
 [component.sync-service]
 source = "target/wasm32-wasip1/release/sync_service.wasm"


### PR DESCRIPTION
Fermyon Spin has native support for cron triggers (`spin add cron` / `[[trigger.cron]]`). 

Instead of relying on external ping services (like cron-job.org or Android app background fetches) to keep the system resilient when the Python MCP server is down, we are utilizing the native Spin Cron trigger to execute our `failover-sync` logic.

This PR uncomment the `[[trigger.cron]]` block in `spin.toml` and schedules it to run every 2 hours. The `#[cron_component]` is already scaffolded in `lib.rs` and properly abstracted to use the `perform_failover_sync` logic without interfering with the HTTP handlers.

This achieves the "Autonomous High Availability" milestone. If the laptop is closed, the Spin Cloud Brain wakes itself up and scrapes Clozemaster.

Closes #100