### PR TITLE
fix: prevent CLI from leaking auth tokens in plaintext

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -10,6 +10,10 @@ import logging
 def setup_logging(verbose: bool):
     level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    
+    # Silence third-party loggers that leak credentials in URLs
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 async def run_nag_eval(args):
     """Evaluate the reminder heuristics without triggering a send."""


### PR DESCRIPTION
### Summary
When using the `mecris` CLI, third-party libraries like `httpx` (used by `beeminder_client.py`) were logging requests at the `INFO` level. Because the CLI set the root logger to `INFO`, this caused the full URLs of outgoing requests to be printed to the terminal.

Since Beeminder passes the `auth_token` as a query parameter in the URL, this inadvertently leaked the secret token in plaintext.

### Fix
Silenced the `httpx` and `urllib3` loggers by setting them to `WARNING` in `setup_logging()`, ensuring credentials remain hidden during normal operation.