### PR TITLE
feat: implement dynamic context-aware nagging time windows

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -204,14 +204,20 @@ async def get_narrator_context(user_id: str = None) -> Dict[str, Any]:
             if isinstance(latest_cloud_walk.get("start_time"), datetime):
                 latest_cloud_walk["start_time"] = latest_cloud_walk["start_time"].isoformat()
         
-        # Fetch user preferences for vacation_mode
+        # Fetch user preferences for vacation_mode and time windows
         target_phone = os.getenv('TWILIO_TO_NUMBER')
         vacation_mode = False
+        time_window_start = 13
+        time_window_end = 17
+        
         if target_phone:
             from sms_consent_manager import consent_manager
             user_prefs = await asyncio.to_thread(consent_manager.get_user_preferences, target_phone)
             if user_prefs:
-                vacation_mode = user_prefs.get("preferences", {}).get("vacation_mode", False)
+                prefs = user_prefs.get("preferences", {})
+                vacation_mode = prefs.get("vacation_mode", False)
+                time_window_start = prefs.get("time_window_start", 13)
+                time_window_end = prefs.get("time_window_end", 17)
 
         # Weather-aware logic
         weather = await asyncio.to_thread(weather_service.get_weather)
@@ -262,7 +268,10 @@ async def get_narrator_context(user_id: str = None) -> Dict[str, Any]:
                 "is_leader": scheduler.is_leader,
                 "process_id": scheduler.process_id
             },
-            "vacation_mode": vacation_mode, "last_updated": datetime.now().isoformat()
+            "vacation_mode": vacation_mode, 
+            "time_window_start": time_window_start,
+            "time_window_end": time_window_end,
+            "last_updated": datetime.now().isoformat()
         }
     except Exception as e:
         logger.error(f"Failed to build narrator context: {e}")

--- a/services/reminder_service.py
+++ b/services/reminder_service.py
@@ -62,8 +62,11 @@ class ReminderService:
             else:
                 logger.info(f"Emergency reminder suppressed by cooldown ({hours_since_emergency:.1f}h since last)")
 
-        # 2. Walk Reminders (Afternoon window: 1 PM - 5 PM)
-        if 13 <= current_hour <= 17:
+        # 2. Walk Reminders (Dynamic window based on user preferences)
+        time_window_start = context.get("time_window_start", 13)
+        time_window_end = context.get("time_window_end", 17)
+        
+        if time_window_start <= current_hour <= time_window_end:
             if not has_walked:
                 # Cooldown: 2.5 hours between walk nags
                 hours_since_walk = await self._get_hours_since_last("walk_reminder", user_id)


### PR DESCRIPTION
### Summary
This implements Item #3 on our Autonomous Nagging System plan: **Dynamic / Context-Aware Windows**. 

Previously, the walk reminder was hardcoded to fire between `13:00` (1 PM) and `17:00` (5 PM). This PR extracts the user's specific notification preferences (like `time_window_start` and `time_window_end`) and passes them into the narrator context, allowing the `ReminderService` to make user-specific schedule decisions.

### Changes
*   **Context Payload**: `mcp_server.py` now extracts `time_window_start` and `time_window_end` from the `sms_consent_manager` (falling back to 13 and 17 if not set) and injects them into the narrator context.
*   **Heuristic Engine**: `ReminderService` now reads these bounds dynamically from the context payload rather than hardcoding the `13 <= current_hour <= 17` logic.

### Why this matters
A true cognitive agent should adapt to the user's schedule. By exposing these bounds to the heuristic engine, we can later have Claude (or another agent) negotiate and update these windows based on historical activity patterns, without needing code changes.