### PR TITLE
fix(rust)+test(python): /internal/failover-sync return fix + 9 handler tests (446 total)

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,20 +1,19 @@
-# Next Session: PR #184 (kingdonb/mecris) awaiting kingdonb review/merge
+# Next Session: Dispatch pr-test after 10b427a push; confirm Python ≥461
 
-## Current Status (2026-04-15)
-- **PR #184 open on kingdonb/mecris** (yebyen:main → kingdonb:main): Contains Rust fix (`f5a4b09`), 9 Python handler tests (`f568c15`), archive commit (`993c4b3`). Awaiting kingdonb review/merge.
-- **pr-test run 24480880265**: Python **446 ✅**, Rust **91 ✅**, Android ✅ — all green. Validation complete.
-- **yebyen/mecris is 3 commits ahead of kingdonb/mecris**: `f5a4b09`, `f568c15`, `993c4b3` pending in PR #184.
+## Current Status (2026-04-16)
+- **PR #184 still open on kingdonb/mecris** (yebyen:main → kingdonb:main): Now 5 commits ahead. Awaiting kingdonb review/merge.
+- **15 new VirtualBudgetManager tests** committed at `10b427a` — `tests/test_virtual_budget_manager.py`. Expected Python baseline: **461** (446 + 15).
+- **pr-test not yet dispatched**: push must land on GitHub before dispatch. Next session dispatches pr-test.
 - **Satellite crate tests (147 total)**: In code but NOT yet in CI — requires workflow PAT fix (yebyen/mecris#142).
 - **Akamai Functions (Trial)**: `sync-service` deployed. Cron jobs: `trigger-reminders` (2h), `failover-sync-edt` (04:05 UTC), `failover-sync-est` (05:05 UTC).
 
 ## Verified This Session
-- [x] **PR #182 merged by kingdonb**: Confirmed merged at `1aabc8f5` (2026-04-15T20:12:10Z).
-- [x] **PR #184 created**: kingdonb/mecris#184 (yebyen:main → kingdonb:main) — 3 commits ahead.
-- [x] **pr-test run 24480880265**: Python **446 passed, 4 skipped** ✅ — 9 new tests confirmed counted.
-- [x] **Rust fix verified in CI**: 91 Rust tests pass ✅ (`f5a4b09` resolves compile error from `be513c92`).
+- [x] **PR #184 still open**: Confirmed open as of 2026-04-16T00:00Z — kingdonb/mecris at `94f2c54`.
+- [x] **15 VirtualBudgetManager tests written and committed**: `10b427a` — closes yebyen/mecris#195 (partial, pending pr-test).
 
 ## Pending Verification (Next Session)
-- [ ] **Confirm PR #184 merged by kingdonb**: Check kingdonb/mecris main for commits through `993c4b3`.
+- [ ] **Dispatch pr-test for PR #184**: Run `/mecris-pr-test 184` after push lands — confirm Python ≥461 (446+15), Rust 91 ✅.
+- [ ] **Confirm PR #184 merged by kingdonb**: Check kingdonb/mecris main for commits through `10b427a`.
 - [ ] **Confirm Akamai cron jobs firing**: Check Akamai logs for `trigger-reminders`, `failover-sync-edt`, `failover-sync-est` executions.
 - [ ] **Akamai E2E Logic Test**: Manually POST to `/internal/failover-sync` on Akamai endpoint.
 - [ ] **Security Hardening (Akamai)**: Unauthenticated `/internal/*` endpoints need API key or IP whitelist.
@@ -40,7 +39,8 @@
 - **Rust compile fix pattern**: All branches in `handle_sync_service` that return a value must use explicit `return`. Bare `match` without `return` causes type error (expected `()`, found `Result<Response, _>`).
 - **Test isolation pattern**: Tests that import `mcp_server` must use `sys.modules.pop("mcp_server", None)` + `patch.dict(os.environ, ...)` + `patch("psycopg2.connect")` before importing.
 - **mcp_server handler test patterns** (`test_mcp_server_handlers.py`): Patch `mcp_server.resolve_target_user` for auth guard tests; patch `mcp_server.usage_tracker` for delegation tests; patch `mcp_server.weather_service` for weather tests.
-- **Python test count baseline**: 446 passed (4 skipped) as of pr-test run 24480880265. New baseline: **446**.
+- **VirtualBudgetManager test pattern**: Patch `virtual_budget_manager.credentials_manager.resolve_user_id` + omit `NEON_DB_URL` → no DB needed for pure/no-DB tests.
+- **Python test count baseline**: 446 passed (4 skipped) as of pr-test run 24480880265. New commit adds 15 more; expected: **461**.
 - **schema.sql budget_tracking schema**: columns are `budget_period_start TEXT NOT NULL`, `budget_period_end TEXT NOT NULL`, `total_budget DOUBLE PRECISION NOT NULL`, `remaining_budget DOUBLE PRECISION NOT NULL`, `user_id UNIQUE REFERENCES users(pocket_id_sub)`.
 - **Upstream sync pattern**: `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
 - **Groq-Beeminder sync**: kingdonb's `9bdf4e7` added automated @TARE reset logic and DB-backed identity resolution. Unit tests for Groq-Beeminder sync in `test_groq_beeminder_sync.py`.

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,40 +1,49 @@
-# Next Session: Verify new handler tests (≥437 Python) via pr-test; await kingdonb merge of PR #182
+# Next Session: Run pr-test to verify Rust fix + 446 Python baseline (f568c15)
 
 ## Current Status (2026-04-15)
-- **Akamai Functions Deployment (Trial)**: `sync-service` deployed to Akamai (`394b84e7-760c-4336-975b-653c17fdb446`).
-- **Cron Jobs Active**: `trigger-reminders` (2h), `failover-sync-edt` (04:05 UTC), `failover-sync-est` (05:05 UTC).
-- **PR #182 open on kingdonb/mecris** (yebyen:main → kingdonb:main): Twilio webhook Phase 2 + satellite crate tests + gauge type + CredentialsManager tests + update_pump_multiplier tests + HealthChecker tests + BeeminderClient.add_datapoint tests + mcp_server handler tests. Awaiting kingdonb review/merge.
-- **pr-test confirmed green at HEAD `e8130a7` (PR #182 baseline)**: 423 Python ✅, 91 Rust ✅, Android ✅. Run: https://github.com/yebyen/mecris/actions/runs/24470904515
-- **yebyen/mecris is 15 commits ahead of kingdonb/mecris**: all in PR #182 plus new commit `a566629`.
-- **New commit `a566629`** — 14 unit tests for mcp_server.py handler functions. Expected Python count: **437**.
+- **PR #182 open on kingdonb/mecris** (yebyen:main → kingdonb:main): Awaiting kingdonb review/merge.
+- **pr-test run 24475982299**: Python 437 ✅, Android ✅, Rust ❌ (compile error in kingdonb's `be513c92` — missing `return` before `match` in `/internal/failover-sync` handler).
+- **Rust compile error FIXED**: `f5a4b09` adds `return` before the `match` in `handle_sync_service` failover-sync branch. Fix compiles clean (91 tests pass locally). Needs pr-test to confirm in CI.
+- **9 new Python tests committed** at `f568c15` — `get_recent_usage`, `get_weather_full_report`, `add_goal`, `update_budget`, `complete_goal` (auth guard + delegation). Expected Python count: **446** (437 + 9).
+- **yebyen/mecris is ahead of kingdonb/mecris**: kingdonb merged yebyen at `1aabc8f5`, then added `be513c92` + `94f2c543`; bot added `f5a4b09` + `f568c15` on top.
+- **Akamai Functions (Trial)**: `sync-service` deployed. Cron jobs: `trigger-reminders` (2h), `failover-sync-edt` (04:05 UTC), `failover-sync-est` (05:05 UTC).
 - **Satellite crate tests (147 total)**: In code but NOT yet in CI — requires workflow PAT fix (yebyen/mecris#142).
 
 ## Verified This Session
-- [x] **Akamai Deployment Success**: `sync-service` live with live Neon/Twilio/Weather variables.
-- [x] **Akamai Cron Scheduling**: 3 jobs active via `spin aka cron create`.
-- [x] **pr-test green at baseline `e8130a7`**: 423 Python (4 skipped), 91 Rust, Android BUILD SUCCESSFUL.
-- [x] **14 new mcp_server handler tests committed** at `a566629`.
-- [x] **Added `/internal/failover-sync` route** to `sync-service` for unauthenticated cron triggers.
+- [x] **pr-test run 24475982299**: Python **437 passed, 4 skipped** — baseline confirmed.
+- [x] **Rust compile error root-caused**: kingdonb's `be513c92` (`/internal/failover-sync` route) missing `return` before `match run_clozemaster_scraper(...)`.
+- [x] **Rust fix committed** at `f5a4b09`: `return match ...;` — 91 sync-service tests pass locally.
+- [x] **9 new mcp_server handler tests committed** at `f568c15`: covers `get_recent_usage`, `get_weather_full_report`, `add_goal`, `update_budget`, `complete_goal`.
 
 ## Pending Verification (Next Session)
-- [ ] **Confirm Akamai cron jobs firing**: Check Akamai logs to determine if `trigger-reminders`, `failover-sync-edt`, and `failover-sync-est` are executing correctly.
-- [ ] **Akamai E2E Logic Test**: Manually `POST` to `/internal/failover-sync` and `/internal/trigger-reminders` on the Akamai endpoint to verify cloud behavior.
-- [ ] **Security Hardening (Akamai)**: Address the unauthenticated `/internal/*` endpoints. Currently open for experimentation but needs an API key or IP whitelist.
-- [ ] **Dispatch pr-test for PR #182 to verify Python count ≥ 437**: `a566629` is now on GitHub after bot workflow push. Run pr-test and confirm new baseline.
-- [ ] **Confirm PR #182 merged by kingdonb**: check kingdonb/mecris main for commits up to `a566629`.
+- [ ] **Dispatch pr-test for PR #182 (or latest yebyen:main) to verify**: Rust should now pass (fix in `f5a4b09`); Python should show **446** (9 new tests in `f568c15`). Run ID from this session: 24475982299 (pre-fix). Next session's run should show Rust ✅.
+- [ ] **Confirm PR #182 merged by kingdonb**: Check kingdonb/mecris main for commits through `f568c15`.
+- [ ] **Confirm Akamai cron jobs firing**: Check Akamai logs for `trigger-reminders`, `failover-sync-edt`, `failover-sync-est` executions.
+- [ ] **Akamai E2E Logic Test**: Manually POST to `/internal/failover-sync` on Akamai endpoint.
+- [ ] **Security Hardening (Akamai)**: Unauthenticated `/internal/*` endpoints need API key or IP whitelist.
 - [ ] **Run 004_user_location.sql against live Neon**: `psql $NEON_DB_URL -f scripts/migrations/004_user_location.sql`.
 - [ ] **Twilio webhook Phase 2 live E2E**: Requires Twilio variables in Fermyon Cloud.
 - [ ] **Multi-Tenancy — Android UI Gaps**: Add "log out" button, phone/location settings, preferred health source. Tracked in kingdonb/mecris#168.
 - [ ] **Rust test gap (workflow fix)**: Apply fix from yebyen/mecris#142. Needs `workflow` PAT.
-- [ ] **Multiplier Sync Validation**: Verify setting the Review Pump lever in Android updates multiplier in Neon.
+- [ ] **Multiplier Sync Validation**: Verify Android Review Pump lever updates `pump_multiplier` in Neon.
 
 ## Infrastructure Notes
 - **Akamai Functions (Trial)**: Persistent cron triggers for reminders and failover syncing.
-  - `/internal/failover-sync` (POST): Unauthenticated sync for cron.
+  - `/internal/failover-sync` (POST): Unauthenticated sync for cron (Rust compile fix in `f5a4b09`).
   - `/internal/trigger-reminders` (POST): Unauthenticated reminder evaluation for cron.
 - Spin Cron trigger is **DISABLED** in `spin.toml` — do not re-enable.
 - `MECRIS_MODE=standalone` bypasses JWKS for local dev; `MECRIS_MODE=cloud` enforces RSA verification.
 - `MASTER_ENCRYPTION_KEY` must be a 64-char hex string (32-byte AES-256 key).
+- **Classic PAT scope**: `GITHUB_CLASSIC_PAT` has `repo` scope ONLY — no `workflow` scope.
+- **Fine-grained PAT**: `GITHUB_TOKEN` scoped to yebyen/mecris only.
 - **NEXT_SESSION.md merge conflict is permanently fixed**: `.gitattributes merge=union` on yebyen/mecris:main.
-- **Rust satellite crates**: 158 tests total across 6 crates (sync-service 91, boris-fiona-walker 28, others 39).
-- **Akamai Next Run**: 22:00 UTC (trigger-reminders), 04:05 UTC (failover-sync-edt), 05:05 UTC (failover-sync-est).
+- **Python venv not present in bot runner**: Validate Python tests via pr-test workflow only.
+- **pr-test.yml push constraint**: Dispatch pr-test ONLY after commits land on GitHub (next session after push).
+- **Rust satellite crates**: 91 tests in sync-service, 28 in boris-fiona-walker, others not in CI yet.
+- **Rust compile fix pattern**: All branches in `handle_sync_service` that return a value must use explicit `return`. Bare `match` without `return` causes type error (expected `()`, found `Result<Response, _>`).
+- **Test isolation pattern**: Tests that import `mcp_server` must use `sys.modules.pop("mcp_server", None)` + `patch.dict(os.environ, ...)` + `patch("psycopg2.connect")` before importing.
+- **mcp_server handler test patterns** (`test_mcp_server_handlers.py`): Patch `mcp_server.resolve_target_user` for auth guard tests; patch `mcp_server.usage_tracker` for delegation tests; patch `mcp_server.weather_service` for weather tests.
+- **Python test count baseline**: 437 passed (4 skipped) as of pr-test run 24475982299. Expected after `f568c15`: **446 passed**.
+- **schema.sql budget_tracking schema**: columns are `budget_period_start TEXT NOT NULL`, `budget_period_end TEXT NOT NULL`, `total_budget DOUBLE PRECISION NOT NULL`, `remaining_budget DOUBLE PRECISION NOT NULL`, `user_id UNIQUE REFERENCES users(pocket_id_sub)`.
+- **Upstream sync pattern**: `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
+- **Groq-Beeminder sync**: kingdonb's `9bdf4e7` added automated @TARE reset logic and DB-backed identity resolution. Unit tests for Groq-Beeminder sync in `test_groq_beeminder_sync.py`.

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,23 +1,20 @@
-# Next Session: Run pr-test to verify Rust fix + 446 Python baseline (f568c15)
+# Next Session: PR #184 (kingdonb/mecris) awaiting kingdonb review/merge
 
 ## Current Status (2026-04-15)
-- **PR #182 open on kingdonb/mecris** (yebyen:main → kingdonb:main): Awaiting kingdonb review/merge.
-- **pr-test run 24475982299**: Python 437 ✅, Android ✅, Rust ❌ (compile error in kingdonb's `be513c92` — missing `return` before `match` in `/internal/failover-sync` handler).
-- **Rust compile error FIXED**: `f5a4b09` adds `return` before the `match` in `handle_sync_service` failover-sync branch. Fix compiles clean (91 tests pass locally). Needs pr-test to confirm in CI.
-- **9 new Python tests committed** at `f568c15` — `get_recent_usage`, `get_weather_full_report`, `add_goal`, `update_budget`, `complete_goal` (auth guard + delegation). Expected Python count: **446** (437 + 9).
-- **yebyen/mecris is ahead of kingdonb/mecris**: kingdonb merged yebyen at `1aabc8f5`, then added `be513c92` + `94f2c543`; bot added `f5a4b09` + `f568c15` on top.
-- **Akamai Functions (Trial)**: `sync-service` deployed. Cron jobs: `trigger-reminders` (2h), `failover-sync-edt` (04:05 UTC), `failover-sync-est` (05:05 UTC).
+- **PR #184 open on kingdonb/mecris** (yebyen:main → kingdonb:main): Contains Rust fix (`f5a4b09`), 9 Python handler tests (`f568c15`), archive commit (`993c4b3`). Awaiting kingdonb review/merge.
+- **pr-test run 24480880265**: Python **446 ✅**, Rust **91 ✅**, Android ✅ — all green. Validation complete.
+- **yebyen/mecris is 3 commits ahead of kingdonb/mecris**: `f5a4b09`, `f568c15`, `993c4b3` pending in PR #184.
 - **Satellite crate tests (147 total)**: In code but NOT yet in CI — requires workflow PAT fix (yebyen/mecris#142).
+- **Akamai Functions (Trial)**: `sync-service` deployed. Cron jobs: `trigger-reminders` (2h), `failover-sync-edt` (04:05 UTC), `failover-sync-est` (05:05 UTC).
 
 ## Verified This Session
-- [x] **pr-test run 24475982299**: Python **437 passed, 4 skipped** — baseline confirmed.
-- [x] **Rust compile error root-caused**: kingdonb's `be513c92` (`/internal/failover-sync` route) missing `return` before `match run_clozemaster_scraper(...)`.
-- [x] **Rust fix committed** at `f5a4b09`: `return match ...;` — 91 sync-service tests pass locally.
-- [x] **9 new mcp_server handler tests committed** at `f568c15`: covers `get_recent_usage`, `get_weather_full_report`, `add_goal`, `update_budget`, `complete_goal`.
+- [x] **PR #182 merged by kingdonb**: Confirmed merged at `1aabc8f5` (2026-04-15T20:12:10Z).
+- [x] **PR #184 created**: kingdonb/mecris#184 (yebyen:main → kingdonb:main) — 3 commits ahead.
+- [x] **pr-test run 24480880265**: Python **446 passed, 4 skipped** ✅ — 9 new tests confirmed counted.
+- [x] **Rust fix verified in CI**: 91 Rust tests pass ✅ (`f5a4b09` resolves compile error from `be513c92`).
 
 ## Pending Verification (Next Session)
-- [ ] **Dispatch pr-test for PR #182 (or latest yebyen:main) to verify**: Rust should now pass (fix in `f5a4b09`); Python should show **446** (9 new tests in `f568c15`). Run ID from this session: 24475982299 (pre-fix). Next session's run should show Rust ✅.
-- [ ] **Confirm PR #182 merged by kingdonb**: Check kingdonb/mecris main for commits through `f568c15`.
+- [ ] **Confirm PR #184 merged by kingdonb**: Check kingdonb/mecris main for commits through `993c4b3`.
 - [ ] **Confirm Akamai cron jobs firing**: Check Akamai logs for `trigger-reminders`, `failover-sync-edt`, `failover-sync-est` executions.
 - [ ] **Akamai E2E Logic Test**: Manually POST to `/internal/failover-sync` on Akamai endpoint.
 - [ ] **Security Hardening (Akamai)**: Unauthenticated `/internal/*` endpoints need API key or IP whitelist.
@@ -43,7 +40,7 @@
 - **Rust compile fix pattern**: All branches in `handle_sync_service` that return a value must use explicit `return`. Bare `match` without `return` causes type error (expected `()`, found `Result<Response, _>`).
 - **Test isolation pattern**: Tests that import `mcp_server` must use `sys.modules.pop("mcp_server", None)` + `patch.dict(os.environ, ...)` + `patch("psycopg2.connect")` before importing.
 - **mcp_server handler test patterns** (`test_mcp_server_handlers.py`): Patch `mcp_server.resolve_target_user` for auth guard tests; patch `mcp_server.usage_tracker` for delegation tests; patch `mcp_server.weather_service` for weather tests.
-- **Python test count baseline**: 437 passed (4 skipped) as of pr-test run 24475982299. Expected after `f568c15`: **446 passed**.
+- **Python test count baseline**: 446 passed (4 skipped) as of pr-test run 24480880265. New baseline: **446**.
 - **schema.sql budget_tracking schema**: columns are `budget_period_start TEXT NOT NULL`, `budget_period_end TEXT NOT NULL`, `total_budget DOUBLE PRECISION NOT NULL`, `remaining_budget DOUBLE PRECISION NOT NULL`, `user_id UNIQUE REFERENCES users(pocket_id_sub)`.
 - **Upstream sync pattern**: `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
 - **Groq-Beeminder sync**: kingdonb's `9bdf4e7` added automated @TARE reset logic and DB-backed identity resolution. Unit tests for Groq-Beeminder sync in `test_groq_beeminder_sync.py`.

--- a/mecris-go-spin/sync-service/src/lib.rs
+++ b/mecris-go-spin/sync-service/src/lib.rs
@@ -200,7 +200,7 @@ async fn handle_sync_service(req: Request) -> anyhow::Result<impl IntoResponse> 
         }
         let db_url = variables::get("db_url").map_err(|e| anyhow::anyhow!("db_url fetch failed: {:?}", e))?;
         let default_user_id = "c0a81a4b-115a-4eb6-bc2c-40908c58bf64";
-        match run_clozemaster_scraper(&db_url, default_user_id).await {
+        return match run_clozemaster_scraper(&db_url, default_user_id).await {
             Ok(_) => {
                 let resp = StatusResponse { status: "success".to_string(), message: "Cloud sync complete (Autonomous)".to_string() };
                 Ok(Response::builder().status(200).header("content-type", "application/json").body(serde_json::to_string(&resp).unwrap()).build())
@@ -209,7 +209,7 @@ async fn handle_sync_service(req: Request) -> anyhow::Result<impl IntoResponse> 
                 let resp = StatusResponse { status: "error".to_string(), message: format!("Cloud sync failed: {:?}", e) };
                 Ok(Response::builder().status(500).header("content-type", "application/json").body(serde_json::to_string(&resp).unwrap()).build())
             }
-        }
+        };
     } else if path == "/internal/twilio-webhook" {
         if req.method() != &spin_sdk::http::Method::Post {
             return Ok(Response::builder().status(405).body("Method Not Allowed").build());

--- a/session_log.md
+++ b/session_log.md
@@ -1388,3 +1388,13 @@ This document summarizes the collaborative debugging session to establish a func
 **Skipped**: pr-test re-run to confirm Rust fix and 446 Python — push constraint (fixes land on GitHub after bot workflow ends). Next session must run pr-test.
 
 **Next**: Dispatch pr-test for PR #182 / yebyen:main HEAD; confirm Rust ✅ and Python ≥446. Then await kingdonb merge of PR #182.
+
+## 2026-04-15 🏛️ — Verify Rust fix + 446 Python baseline via pr-test (#184)
+
+**Planned**: yebyen/mecris#194 — Create PR yebyen:main → kingdonb:main (3 commits ahead), dispatch pr-test, confirm Rust 91 ✅ and Python 446 ✅.
+
+**Done**: Oriented — confirmed PR #182 merged at `1aabc8f5`; yebyen 3 commits ahead of kingdonb. Created plan yebyen/mecris#194. Opened PR kingdonb/mecris#184 (Rust fix `f5a4b09` + 9 Python tests `f568c15` + archive `993c4b3`). Dispatched pr-test (run 24480880265) — Python **446 ✅**, Rust **91 ✅**, Android ✅. All validation criteria met.
+
+**Skipped**: Nothing — single focused verification task, fully completed.
+
+**Next**: Await kingdonb review/merge of PR #184. If merged, yebyen/mecris will be in sync. Consider Akamai E2E verification or security hardening of `/internal/*` endpoints as next coding task.

--- a/session_log.md
+++ b/session_log.md
@@ -1373,3 +1373,18 @@ This document summarizes the collaborative debugging session to establish a func
 **Skipped**: Full pr-test count verification for `a566629` — push constraint means new tests not on GitHub until bot workflow ends. Count verification deferred to next session.
 
 **Next**: Dispatch pr-test for PR #182 after `a566629` lands, confirm Python count rises to ≥437. Await kingdonb merge of PR #182.
+
+## 2026-04-15 🏛️ — Verify 437 Python baseline, fix Rust compile error, add 9 more handler tests
+
+**Planned**: Dispatch pr-test for PR #182 to confirm 437 Python; add more Python test coverage (plan: yebyen/mecris#193).
+
+**Done**: 
+- pr-test dispatched (run 24475982299): **Python 437 ✅, Android ✅, Rust ❌**. Python baseline confirmed.
+- Rust compile error root-caused: kingdonb's `be513c92` added `/internal/failover-sync` route with bare `match` (missing `return`). Type error: expected `()`, found `Result<Response, _>`.
+- Synced local to `94f2c54` (kingdonb had pushed 3 commits to yebyen:main directly).
+- Fix committed at `f5a4b09`: added `return` before `match` in failover-sync branch. 91 Rust tests pass locally.
+- 9 new Python tests committed at `f568c15`: `get_recent_usage` (2), `get_weather_full_report` (1), `add_goal` (2), `update_budget` (2), `complete_goal` (2). All follow auth-guard + delegation pattern. Expected count: 446.
+
+**Skipped**: pr-test re-run to confirm Rust fix and 446 Python — push constraint (fixes land on GitHub after bot workflow ends). Next session must run pr-test.
+
+**Next**: Dispatch pr-test for PR #182 / yebyen:main HEAD; confirm Rust ✅ and Python ≥446. Then await kingdonb merge of PR #182.

--- a/session_log.md
+++ b/session_log.md
@@ -1398,3 +1398,13 @@ This document summarizes the collaborative debugging session to establish a func
 **Skipped**: Nothing — single focused verification task, fully completed.
 
 **Next**: Await kingdonb review/merge of PR #184. If merged, yebyen/mecris will be in sync. Consider Akamai E2E verification or security hardening of `/internal/*` endpoints as next coding task.
+
+## 2026-04-16 🏛️ — VirtualBudgetManager unit tests (15) — yebyen/mecris#195
+
+**Planned**: Add `tests/test_virtual_budget_manager.py` covering pure `calculate_cost` math and no-DB early-return paths; raise Python baseline from 446 to ≥455.
+
+**Done**: 15 tests written and committed at `10b427a` — exceeded target (446+15=461). Covers `Provider` enum (2), `calculate_cost` for known models and fallbacks (7), `can_afford`/`get_budget_status`/`get_usage_summary`/`reset_daily_budget` no-DB paths (4), `record_usage` no-afford + emergency_override paths (2). Patch pattern: `virtual_budget_manager.credentials_manager.resolve_user_id` + omit `NEON_DB_URL`.
+
+**Skipped**: pr-test dispatch — push must land on GitHub before test run can be triggered (next session constraint).
+
+**Next**: Dispatch pr-test for PR #184 to confirm Python ≥461 ✅, then await kingdonb merge.

--- a/tests/test_cron_validation.py
+++ b/tests/test_cron_validation.py
@@ -1,0 +1,58 @@
+"""
+E2E Validation for Akamai Cron Triggers (#183).
+This test hits the live Akamai endpoint and verifies side effects in Neon.
+"""
+import os
+import httpx
+import pytest
+import psycopg2
+from datetime import datetime, timezone
+
+AKAMAI_BASE_URL = "https://394b84e7-760c-4336-975b-653c17fdb446.fwf.app"
+DEFAULT_USER_ID = "c0a81a4b-115a-4eb6-bc2c-40908c58bf64"
+
+def get_last_updated(language):
+    db_url = os.getenv("NEON_DB_URL")
+    if not db_url:
+        pytest.skip("NEON_DB_URL not set")
+    
+    conn = psycopg2.connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT last_updated FROM language_stats WHERE user_id = %s AND language_name = %s",
+                (DEFAULT_USER_ID, language.upper())
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+    finally:
+        conn.close()
+
+@pytest.mark.asyncio
+async def test_akamai_failover_sync_side_effect():
+    """Trigger /internal/failover-sync on Akamai and verify language_stats update."""
+    # 1. Get current state
+    start_time = datetime.now(timezone.utc)
+    old_update = get_last_updated("ARABIC")
+    print(f"Old update: {old_update}")
+
+    # 2. Trigger Akamai
+    url = f"{AKAMAI_BASE_URL}/internal/failover-sync"
+    async with httpx.AsyncClient() as client:
+        # The endpoint expects POST
+        response = await client.post(url, timeout=30.0)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+
+    # 3. Verify side effect in Neon
+    new_update = get_last_updated("ARABIC")
+    print(f"New update: {new_update}")
+    
+    assert new_update is not None
+    # Depending on DB precision and clock skew, we just want it to be recent or newer than old_update
+    if old_update:
+        assert new_update > old_update
+    else:
+        assert new_update > start_time # If it was None before

--- a/tests/test_mcp_server_handlers.py
+++ b/tests/test_mcp_server_handlers.py
@@ -1,15 +1,20 @@
 """
-Tests for mcp_server.py handler functions — yebyen/mecris#192.
+Tests for mcp_server.py handler functions — yebyen/mecris#192, #193.
 
 Covers:
 - _record_governor_spend: bucket routing (gemini/groq/helix/anthropic_api) + exception swallow
 - get_budget_status: auth guard returns error dict when resolve_target_user is None
 - get_budget_status: delegates to usage_tracker.get_budget_status when authenticated
 - get_weather_report: returns combined weather + is_appropriate + recommendation
+- get_weather_full_report: passthrough to weather_service.get_weather()
 - record_usage_session: happy path records usage and governor spend
 - record_usage_session: error path returns error dict when record_usage raises
 - record_claude_code_usage: happy path returns recorded=True with estimated_cost
 - record_claude_code_usage: error path returns error dict
+- get_recent_usage: auth guard + delegates to usage_tracker.get_recent_sessions
+- add_goal: auth guard + delegates to usage_tracker.add_goal
+- update_budget: auth guard + delegates to usage_tracker.update_budget
+- complete_goal: auth guard + delegates to usage_tracker.complete_goal
 """
 
 import sys
@@ -272,3 +277,169 @@ def test_record_claude_code_usage_error_path():
             result = record_claude_code_usage(input_tokens=100, output_tokens=50)
 
     assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# get_recent_usage — auth guard + delegation
+# ---------------------------------------------------------------------------
+
+def test_get_recent_usage_returns_auth_error_when_unauthenticated():
+    """Returns list with error dict when resolve_target_user returns None."""
+    sys.modules.pop("mcp_server", None)
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.resolve_target_user", return_value=None):
+            from mcp_server import get_recent_usage
+            result = get_recent_usage(user_id="unknown")
+
+    assert isinstance(result, list)
+    assert "error" in result[0]
+    assert "Authentication" in result[0]["error"]
+
+
+def test_get_recent_usage_delegates_to_usage_tracker():
+    """Delegates to usage_tracker.get_recent_sessions when authenticated."""
+    sys.modules.pop("mcp_server", None)
+
+    expected = [{"session_id": 1, "tokens": 500}, {"session_id": 2, "tokens": 300}]
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.resolve_target_user", return_value="test-user"), \
+             patch("mcp_server.usage_tracker") as mock_tracker:
+            mock_tracker.get_recent_sessions.return_value = expected
+            from mcp_server import get_recent_usage
+            result = get_recent_usage(limit=5, user_id="test-user")
+
+    assert result == expected
+    mock_tracker.get_recent_sessions.assert_called_once_with(5, "test-user")
+
+
+# ---------------------------------------------------------------------------
+# get_weather_full_report — simple weather_service passthrough
+# ---------------------------------------------------------------------------
+
+def test_get_weather_full_report_returns_weather_dict():
+    """Returns the full weather dict from weather_service.get_weather()."""
+    sys.modules.pop("mcp_server", None)
+
+    fake_weather = {"temp": 72, "condition": "Clear", "humidity": 55, "wind_speed": 8}
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.weather_service") as mock_ws:
+            mock_ws.get_weather.return_value = fake_weather
+            from mcp_server import get_weather_full_report
+            result = get_weather_full_report()
+
+    assert result == fake_weather
+    mock_ws.get_weather.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# add_goal — auth guard + delegation
+# ---------------------------------------------------------------------------
+
+def test_add_goal_returns_auth_error_when_unauthenticated():
+    """Returns error dict when resolve_target_user returns None."""
+    sys.modules.pop("mcp_server", None)
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.resolve_target_user", return_value=None):
+            from mcp_server import add_goal
+            result = add_goal(title="Walk dogs", user_id="unknown")
+
+    assert "error" in result
+    assert "Authentication" in result["error"]
+
+
+def test_add_goal_delegates_to_usage_tracker():
+    """Delegates to usage_tracker.add_goal when authenticated."""
+    sys.modules.pop("mcp_server", None)
+
+    expected = {"goal_id": 42, "title": "Walk dogs", "created": True}
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.resolve_target_user", return_value="test-user"), \
+             patch("mcp_server.usage_tracker") as mock_tracker:
+            mock_tracker.add_goal.return_value = expected
+            from mcp_server import add_goal
+            result = add_goal(title="Walk dogs", priority="high", user_id="test-user")
+
+    assert result == expected
+    mock_tracker.add_goal.assert_called_once_with("Walk dogs", "", "high", None, "test-user")
+
+
+# ---------------------------------------------------------------------------
+# update_budget — auth guard + delegation
+# ---------------------------------------------------------------------------
+
+def test_update_budget_returns_auth_error_when_unauthenticated():
+    """Returns error dict when resolve_target_user returns None."""
+    sys.modules.pop("mcp_server", None)
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.resolve_target_user", return_value=None):
+            from mcp_server import update_budget
+            result = update_budget(remaining_budget=5.0, user_id="unknown")
+
+    assert "error" in result
+    assert "Authentication" in result["error"]
+
+
+def test_update_budget_delegates_to_usage_tracker():
+    """Delegates to usage_tracker.update_budget when authenticated."""
+    sys.modules.pop("mcp_server", None)
+
+    expected = {"updated": True, "remaining_budget": 5.0}
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.resolve_target_user", return_value="test-user"), \
+             patch("mcp_server.usage_tracker") as mock_tracker:
+            mock_tracker.update_budget.return_value = expected
+            from mcp_server import update_budget
+            result = update_budget(remaining_budget=5.0, total_budget=20.0, user_id="test-user")
+
+    assert result == expected
+    mock_tracker.update_budget.assert_called_once_with(5.0, 20.0, None, "test-user")
+
+
+# ---------------------------------------------------------------------------
+# complete_goal — auth guard + delegation
+# ---------------------------------------------------------------------------
+
+def test_complete_goal_returns_auth_error_when_unauthenticated():
+    """Returns error dict when resolve_target_user returns None."""
+    sys.modules.pop("mcp_server", None)
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.resolve_target_user", return_value=None):
+            from mcp_server import complete_goal
+            result = complete_goal(goal_id=7, user_id="unknown")
+
+    assert "error" in result
+    assert "Authentication" in result["error"]
+
+
+def test_complete_goal_delegates_to_usage_tracker():
+    """Delegates to usage_tracker.complete_goal when authenticated."""
+    sys.modules.pop("mcp_server", None)
+
+    expected = {"completed": True, "goal_id": 7}
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.resolve_target_user", return_value="test-user"), \
+             patch("mcp_server.usage_tracker") as mock_tracker:
+            mock_tracker.complete_goal.return_value = expected
+            from mcp_server import complete_goal
+            result = complete_goal(goal_id=7, user_id="test-user")
+
+    assert result == expected
+    mock_tracker.complete_goal.assert_called_once_with(7, "test-user")

--- a/tests/test_virtual_budget_manager.py
+++ b/tests/test_virtual_budget_manager.py
@@ -1,0 +1,182 @@
+"""Unit tests for virtual_budget_manager.py — VirtualBudgetManager class.
+
+Covers:
+- calculate_cost: pure math for known models and fallback to default pricing
+- can_afford: early return when NEON_DB_URL absent
+- get_budget_status: early return when no DB
+- get_usage_summary: early return when no DB
+- reset_daily_budget: early return when no DB
+- record_usage: early returns for no-budget and no-DB paths
+- Provider enum values
+
+All tests run without a live database by omitting NEON_DB_URL from the environment.
+Closes yebyen/mecris#195
+"""
+import os
+import pytest
+from unittest.mock import patch
+from virtual_budget_manager import VirtualBudgetManager, Provider
+
+FAKE_USER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _make_vbm(user_id=FAKE_USER) -> VirtualBudgetManager:
+    """Create VirtualBudgetManager with no DB and a fixed user_id."""
+    env = {}
+    env.pop("NEON_DB_URL", None)
+    with patch.dict(os.environ, env, clear=False):
+        os.environ.pop("NEON_DB_URL", None)
+        with patch(
+            "virtual_budget_manager.credentials_manager.resolve_user_id",
+            return_value=user_id,
+        ):
+            vbm = VirtualBudgetManager(user_id=user_id)
+    return vbm
+
+
+# ---------------------------------------------------------------------------
+# Provider enum
+# ---------------------------------------------------------------------------
+
+class TestProviderEnum:
+    def test_anthropic_value(self):
+        assert Provider.ANTHROPIC.value == "anthropic"
+
+    def test_groq_value(self):
+        assert Provider.GROQ.value == "groq"
+
+
+# ---------------------------------------------------------------------------
+# calculate_cost — pure math, no DB
+# ---------------------------------------------------------------------------
+
+class TestCalculateCost:
+    def setup_method(self):
+        self.vbm = _make_vbm()
+
+    def test_anthropic_sonnet_known_model(self):
+        # claude-3-5-sonnet: input $3/1M, output $15/1M
+        cost = self.vbm.calculate_cost(
+            Provider.ANTHROPIC, "claude-3-5-sonnet-20241022", 1_000_000, 0
+        )
+        assert cost == pytest.approx(3.0, abs=1e-6)
+
+    def test_anthropic_sonnet_output_tokens(self):
+        cost = self.vbm.calculate_cost(
+            Provider.ANTHROPIC, "claude-3-5-sonnet-20241022", 0, 1_000_000
+        )
+        assert cost == pytest.approx(15.0, abs=1e-6)
+
+    def test_groq_llama_70b_known_model(self):
+        # llama-3.3-70b-versatile: $0.08/1M input+output
+        cost = self.vbm.calculate_cost(
+            Provider.GROQ, "llama-3.3-70b-versatile", 1_000_000, 0
+        )
+        assert cost == pytest.approx(0.08, abs=1e-6)
+
+    def test_anthropic_haiku_known_model(self):
+        # claude-3-5-haiku: input $0.25/1M
+        cost = self.vbm.calculate_cost(
+            Provider.ANTHROPIC, "claude-3-5-haiku-20241022", 1_000_000, 0
+        )
+        assert cost == pytest.approx(0.25, abs=1e-6)
+
+    def test_unknown_anthropic_model_falls_back_to_sonnet(self):
+        # Unknown model → fallback is claude-3-5-sonnet pricing ($3/1M input)
+        cost_unknown = self.vbm.calculate_cost(
+            Provider.ANTHROPIC, "claude-9-ultramax", 1_000_000, 0
+        )
+        cost_sonnet = self.vbm.calculate_cost(
+            Provider.ANTHROPIC, "claude-3-5-sonnet-20241022", 1_000_000, 0
+        )
+        assert cost_unknown == pytest.approx(cost_sonnet, abs=1e-6)
+
+    def test_unknown_groq_model_falls_back_to_gpt_oss_120b(self):
+        # Unknown model → fallback is openai/gpt-oss-120b pricing ($0.15/1M)
+        cost_unknown = self.vbm.calculate_cost(
+            Provider.GROQ, "some-new-model", 1_000_000, 0
+        )
+        cost_fallback = self.vbm.calculate_cost(
+            Provider.GROQ, "openai/gpt-oss-120b", 1_000_000, 0
+        )
+        assert cost_unknown == pytest.approx(cost_fallback, abs=1e-6)
+
+    def test_zero_tokens_returns_zero(self):
+        cost = self.vbm.calculate_cost(
+            Provider.ANTHROPIC, "claude-3-5-sonnet-20241022", 0, 0
+        )
+        assert cost == 0.0
+
+
+# ---------------------------------------------------------------------------
+# can_afford — no DB path
+# ---------------------------------------------------------------------------
+
+class TestCanAffordNoDb:
+    def test_returns_cannot_afford_when_no_db(self):
+        vbm = _make_vbm()
+        result = vbm.can_afford(0.50)
+        assert result["can_afford"] is False
+        assert result["reason"] == "No DB"
+
+
+# ---------------------------------------------------------------------------
+# get_budget_status — no DB path
+# ---------------------------------------------------------------------------
+
+class TestGetBudgetStatusNoDb:
+    def test_returns_error_when_no_db(self):
+        vbm = _make_vbm()
+        result = vbm.get_budget_status()
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# get_usage_summary — no DB path
+# ---------------------------------------------------------------------------
+
+class TestGetUsageSummaryNoDb:
+    def test_returns_error_when_no_db(self):
+        vbm = _make_vbm()
+        result = vbm.get_usage_summary()
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# reset_daily_budget — no DB path
+# ---------------------------------------------------------------------------
+
+class TestResetDailyBudgetNoDb:
+    def test_returns_error_when_no_db(self):
+        vbm = _make_vbm()
+        result = vbm.reset_daily_budget()
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# record_usage — no-afford and no-DB paths
+# ---------------------------------------------------------------------------
+
+class TestRecordUsageNoDb:
+    def test_returns_not_recorded_when_cannot_afford(self):
+        """Without DB, can_afford returns False → record_usage short-circuits."""
+        vbm = _make_vbm()
+        result = vbm.record_usage(
+            Provider.ANTHROPIC, "claude-3-5-sonnet-20241022", 1000, 500
+        )
+        assert result["recorded"] is False
+        assert "reason" in result
+        assert "cost" in result
+
+    def test_emergency_override_returns_not_recorded_no_db(self):
+        """With emergency_override=True but no DB, hits no-DB guard and returns not-recorded."""
+        vbm = _make_vbm()
+        result = vbm.record_usage(
+            Provider.ANTHROPIC,
+            "claude-3-5-sonnet-20241022",
+            100,
+            50,
+            emergency_override=True,
+        )
+        assert result["recorded"] is False
+        assert result["reason"] == "No DB configured"


### PR DESCRIPTION
## Summary

- \`f5a4b09\` **fix(rust)**: Add \`return\` before \`match\` in \`handle_sync_service\` \`/internal/failover-sync\` branch — fixes Rust compile error introduced in \`be513c92\` (missing explicit return caused type mismatch: expected \`()\`, found \`Result<Response, _>\`)
- \`f568c15\` **test(python)**: 9 new mcp_server handler tests — \`get_recent_usage\`, \`get_weather_full_report\`, \`add_goal\`, \`update_budget\`, \`complete_goal\` (auth guard + delegation patterns)
- \`993c4b3\` **archive**: Session log for 2026-04-15

Closes yebyen/mecris#193 (partial → complete after pr-test confirms).

## Test plan
- [ ] Rust: 91 unit tests pass (\`cargo test\` in \`mecris-go-spin/sync-service\`)
- [ ] Python: **446 passed, 4 skipped** (up from 437 baseline)
- [ ] Android: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) via mecris-bot (plan: yebyen/mecris#194)