### PR TITLE
feat(android): triggerReminders pulse when MCP is dark

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,23 +1,23 @@
-# Next Session: Dispatch pr-test for kingdonb/mecris#186 (now includes consent flag merge)
+# Next Session: Dispatch pr-test for yebyen:main (triggerReminders + all prior changes)
 
 ## Current Status (2026-04-16)
-- **kingdonb/mecris#186 is still open**: PR from yebyen:main → kingdonb:main; awaiting kingdonb merge.
-- **yebyen:main merged upstream**: `4d6e9d6` integrates kingdonb/mecris #185 (autonomous consent flag, 5 commits). Divergence resolved.
-- **yebyen 6 commits ahead of kingdonb:main, 0 behind** ✅ (clean sync)
-- **Rust test count: 99** (was 95; consent flag merge added 4 tests for `is_autonomous_sync_allowed`).
-- **PR #186 net diff against kingdonb:main is clean**: Shows only yebyen additions — E2E skip guard + API key guard + `internal_api_key_ok` tests.
+- **yebyen:main == kingdonb:main**: PR #186 merged 2026-04-16T17:19:05Z. yebyen is 2 commits ahead (red `a26b53b` + green `cc3336e` for #200).
+- **triggerReminders implemented**: `SyncServiceApi.triggerReminders()` added (`@POST("internal/trigger-reminders")`); `WalkHeuristicsWorker` calls it alongside `triggerCloudSync()` when `mcp_server_active == false`.
+- **CooperativeWorkerTest**: 2 new tests added — `worker triggers reminders when MCP is dark` + `worker DOES NOT trigger reminders when MCP is active`.
+- **Rust 99 tests**: unchanged from prior session.
+- **Python 461 tests (5 skipped)**: baseline from pr-test run 24509446714, unchanged this session.
 
 ## Verified This Session
-- [x] **Upstream sync complete**: Merged kingdonb/mecris main (PR #185, 5 commits) into yebyen:main via `4d6e9d6`.
-- [x] **Merge conflict resolved**: `lib.rs` conflict resolved keeping BOTH API key guard (`16e8cb7`) AND per-user consent flag logic (#185).
-- [x] **Rust 99 tests**: 95 previous + 4 new `is_autonomous_sync_allowed` tests from consent flag merge.
-- [x] **yebyen/mecris#199 complete**: Plan issue closed.
+- [x] **PR #186 merged into kingdonb:main** (`2026-04-16T17:19:05Z`).
+- [x] **yebyen == kingdonb** after PR merge (0/0 divergence at session start).
+- [x] **triggerReminders red+green committed**: `a26b53b` (red), `cc3336e` (green).
+- [x] **yebyen/mecris#200 complete**: Plan issue closed.
 
 ## Pending Verification (Next Session)
-- [ ] **Dispatch pr-test for PR #186**: Run `/mecris-pr-test 186` after CI pushes `4d6e9d6` to GitHub. Expect: 461 Python + 99 Rust pass.
-- [ ] **kingdonb merges #186**: Confirm kingdonb/mecris#186 merged into main (includes E2E skip fix + API key guard + consent flag merge).
+- [ ] **Dispatch pr-test for yebyen:main**: Run `/mecris-pr-test` for any open PR or verify Android unit tests pass. Expect: 461 Python + 99 Rust + Android tests including 2 new CooperativeWorkerTest cases.
+- [ ] **Open PR yebyen:main → kingdonb:main**: Carry forward triggerReminders (a26b53b + cc3336e) as a new PR against kingdonb:main.
 - [ ] **Configure internal_api_key in Fermyon Cloud**: Set `internal_api_key = "<secret>"` in runtime-config; update Akamai cron `curl` calls with `X-Internal-Api-Key: <secret>`. This activates the guard.
-- [ ] **Sync yebyen after #186 merges**: `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit` (only after #186 is merged upstream).
+- [ ] **Sync yebyen after next kingdonb merge**: `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
 - [ ] **Confirm Akamai cron jobs firing**: Check Akamai logs for `trigger-reminders`, `failover-sync-edt`, `failover-sync-est` executions.
 - [ ] **Run 004_user_location.sql against live Neon**: `psql $NEON_DB_URL -f scripts/migrations/004_user_location.sql`.
 - [ ] **Run 005_autonomous_sync_consent.sql against live Neon**: `psql $NEON_DB_URL -f scripts/migrations/005_autonomous_sync_consent.sql`. Adds `autonomous_sync_enabled` and `last_autonomous_sync` columns to `users` table.
@@ -29,7 +29,8 @@
 ## Infrastructure Notes
 - **Akamai Functions (Trial)**: Persistent cron triggers for reminders and failover syncing.
   - `/internal/failover-sync` (POST): Now uses `handle_failover_sync_post()` — per-user consent flag + `last_autonomous_sync` tracking. Guarded by `internal_api_key` Spin variable (backwards compat: no key = allow all).
-  - `/internal/trigger-reminders` (POST): Sends reminders only to users with `autonomous_sync_enabled = true`. Guarded by same key.
+  - `/internal/trigger-reminders` (POST): Sends reminders only to users with `autonomous_sync_enabled = true`. Guarded by same key. Android now also calls this as best-effort pulse when MCP is dark.
+- **triggerReminders design**: `SyncServiceApi.triggerReminders()` sends no auth header — Rust endpoint is gated by `X-Internal-Api-Key` only; with key unset (current), all callers are allowed. When key is set in Fermyon Cloud, only Akamai cron will have the key; Android pulse will gracefully fail with 401 (caught + logged).
 - **New migration**: `005_autonomous_sync_consent.sql` — adds `autonomous_sync_enabled BOOLEAN DEFAULT false` and `last_autonomous_sync TIMESTAMPTZ` to `users` table. Must run before live consent flag is effective.
 - **Rust 99 tests**: 95 original + 4 new `is_autonomous_sync_allowed` tests. `internal_api_key_ok` tests also present (5 tests).
 - Spin Cron trigger is **DISABLED** in `spin.toml` — do not re-enable.

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,29 +1,25 @@
-# Next Session: Dispatch pr-test for yebyen:main (triggerReminders + all prior changes)
+# Next Session: Await merge of kingdonb/mecris#187 (triggerReminders), then sync yebyen
 
 ## Current Status (2026-04-16)
-- **yebyen:main == kingdonb:main**: PR #186 merged 2026-04-16T17:19:05Z. yebyen is 2 commits ahead (red `a26b53b` + green `cc3336e` for #200).
-- **triggerReminders implemented**: `SyncServiceApi.triggerReminders()` added (`@POST("internal/trigger-reminders")`); `WalkHeuristicsWorker` calls it alongside `triggerCloudSync()` when `mcp_server_active == false`.
-- **CooperativeWorkerTest**: 2 new tests added — `worker triggers reminders when MCP is dark` + `worker DOES NOT trigger reminders when MCP is active`.
-- **Rust 99 tests**: unchanged from prior session.
-- **Python 461 tests (5 skipped)**: baseline from pr-test run 24509446714, unchanged this session.
+- **PR #187 open on kingdonb/mecris**: `feat(android): triggerReminders pulse when MCP is dark` — yebyen:main → kingdonb:main. Awaiting kingdonb review/merge.
+- **pr-test run 24531480498**: ✅ success — Python 461 passed (5 skipped), Android BUILD SUCCESSFUL (24 tasks, all CooperativeWorkerTest pass), Rust 99 passed.
+- **yebyen:main is 3 commits ahead of kingdonb:main**: a26b53b (red), cc3336e (green), d8386af (archive). PR #187 carries all three.
+- **Rust test count**: 99 (95 + 4 `is_autonomous_sync_allowed` tests). Android unit tests include 2 new CooperativeWorkerTest cases.
 
 ## Verified This Session
-- [x] **PR #186 merged into kingdonb:main** (`2026-04-16T17:19:05Z`).
-- [x] **yebyen == kingdonb** after PR merge (0/0 divergence at session start).
-- [x] **triggerReminders red+green committed**: `a26b53b` (red), `cc3336e` (green).
-- [x] **yebyen/mecris#200 complete**: Plan issue closed.
+- [x] **PR #187 opened**: kingdonb/mecris#187 `feat(android): triggerReminders pulse when MCP is dark`.
+- [x] **pr-test passed**: run 24531480498 — Python ✅, Android ✅, Rust ✅.
+- [x] **2 new CooperativeWorkerTest cases** confirmed passing in Android test suite.
+- [x] **Plan yebyen/mecris#201 complete**: closed.
 
 ## Pending Verification (Next Session)
-- [ ] **Dispatch pr-test for yebyen:main**: Run `/mecris-pr-test` for any open PR or verify Android unit tests pass. Expect: 461 Python + 99 Rust + Android tests including 2 new CooperativeWorkerTest cases.
-- [ ] **Open PR yebyen:main → kingdonb:main**: Carry forward triggerReminders (a26b53b + cc3336e) as a new PR against kingdonb:main.
-- [ ] **Configure internal_api_key in Fermyon Cloud**: Set `internal_api_key = "<secret>"` in runtime-config; update Akamai cron `curl` calls with `X-Internal-Api-Key: <secret>`. This activates the guard.
-- [ ] **Sync yebyen after next kingdonb merge**: `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
+- [ ] **kingdonb/mecris#187 merged?** Check if kingdonb has merged. If yes: sync yebyen with `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
+- [ ] **Configure internal_api_key in Fermyon Cloud**: Set `internal_api_key = "<secret>"` in runtime-config; update Akamai cron `curl` calls with `X-Internal-Api-Key: <secret>`. This activates the guard. (Needs human with Fermyon access.)
+- [ ] **Run 005_autonomous_sync_consent.sql against live Neon**: `psql $NEON_DB_URL -f scripts/migrations/005_autonomous_sync_consent.sql`. Adds `autonomous_sync_enabled` and `last_autonomous_sync` columns to `users` table. (Needs human with NEON_DB_URL.)
 - [ ] **Confirm Akamai cron jobs firing**: Check Akamai logs for `trigger-reminders`, `failover-sync-edt`, `failover-sync-est` executions.
-- [ ] **Run 004_user_location.sql against live Neon**: `psql $NEON_DB_URL -f scripts/migrations/004_user_location.sql`.
-- [ ] **Run 005_autonomous_sync_consent.sql against live Neon**: `psql $NEON_DB_URL -f scripts/migrations/005_autonomous_sync_consent.sql`. Adds `autonomous_sync_enabled` and `last_autonomous_sync` columns to `users` table.
 - [ ] **Twilio webhook Phase 2 live E2E**: Requires Twilio variables in Fermyon Cloud.
 - [ ] **Multi-Tenancy — Android UI Gaps**: Add "log out" button, phone/location settings, preferred health source. Tracked in kingdonb/mecris#168.
-- [ ] **Rust test gap (workflow fix)**: Apply fix from yebyen/mecris#142. Needs `workflow` PAT.
+- [ ] **Rust test gap (workflow fix)**: Apply fix from yebyen/mecris#142. Needs `workflow` PAT scope — must be applied by kingdonb.
 - [ ] **Multiplier Sync Validation**: Verify Android Review Pump lever updates `pump_multiplier` in Neon.
 
 ## Infrastructure Notes
@@ -37,7 +33,7 @@
 - `MECRIS_MODE=standalone` bypasses JWKS for local dev; `MECRIS_MODE=cloud` enforces RSA verification.
 - `MASTER_ENCRYPTION_KEY` must be a 64-char hex string (32-byte AES-256 key).
 - **Classic PAT scope**: `GITHUB_CLASSIC_PAT` has `repo` scope ONLY — no `workflow` scope.
-- **Fine-grained PAT**: `GITHUB_TOKEN` scoped to yebyen/mecris only.
+- **Fine-grained PAT**: `GITHUB_TOKEN` scoped to yebyen/mecris only. Cannot create PRs on kingdonb/mecris — use `gh pr create` with `GITHUB_CLASSIC_PAT`.
 - **NEXT_SESSION.md merge conflict is permanently fixed**: `.gitattributes merge=union` on yebyen/mecris:main.
 - **Python venv not present in bot runner**: Validate Python tests via pr-test workflow only.
 - **pr-test.yml push constraint**: Dispatch pr-test ONLY after commits land on GitHub (next session after push).
@@ -46,7 +42,7 @@
 - **Test isolation pattern**: Tests that import `mcp_server` must use `sys.modules.pop("mcp_server", None)` + `patch.dict(os.environ, ...)` + `patch("psycopg2.connect")` before importing.
 - **mcp_server handler test patterns** (`test_mcp_server_handlers.py`): Patch `mcp_server.resolve_target_user` for auth guard tests; patch `mcp_server.usage_tracker` for delegation tests; patch `mcp_server.weather_service` for weather tests.
 - **VirtualBudgetManager test pattern**: Patch `virtual_budget_manager.credentials_manager.resolve_user_id` + omit `NEON_DB_URL` → no DB needed for pure/no-DB tests.
-- **Python test count baseline**: 461 passed (5 skipped) confirmed in pr-test run 24509446714. Akamai E2E test now permanently skipped in CI.
+- **Python test count baseline**: 461 passed (5 skipped) confirmed in pr-test run 24531480498. Akamai E2E test now permanently skipped in CI.
 - **schema.sql budget_tracking schema**: columns are `budget_period_start TEXT NOT NULL`, `budget_period_end TEXT NOT NULL`, `total_budget DOUBLE PRECISION NOT NULL`, `remaining_budget DOUBLE PRECISION NOT NULL`, `user_id UNIQUE REFERENCES users(pocket_id_sub)`.
 - **Upstream sync pattern**: `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
 - **Groq-Beeminder sync**: kingdonb's `9bdf4e7` added automated @TARE reset logic and DB-backed identity resolution. Unit tests for Groq-Beeminder sync in `test_groq_beeminder_sync.py`.

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,24 +1,28 @@
-# Next Session: Await merge of kingdonb/mecris#187 (triggerReminders), then sync yebyen
+# Next Session: Dispatch pr-test for kingdonb/mecris#187 after push (now includes Profile Settings)
 
 ## Current Status (2026-04-16)
 - **PR #187 open on kingdonb/mecris**: `feat(android): triggerReminders pulse when MCP is dark` — yebyen:main → kingdonb:main. Awaiting kingdonb review/merge.
-- **pr-test run 24531480498**: ✅ success — Python 461 passed (5 skipped), Android BUILD SUCCESSFUL (24 tasks, all CooperativeWorkerTest pass), Rust 99 passed.
-- **yebyen:main is 3 commits ahead of kingdonb:main**: a26b53b (red), cc3336e (green), d8386af (archive). PR #187 carries all three.
-- **Rust test count**: 99 (95 + 4 `is_autonomous_sync_allowed` tests). Android unit tests include 2 new CooperativeWorkerTest cases.
+- **6 new commits on yebyen:main since PR opened**: 3 from last session (triggerReminders) + 3 new (ProfilePreferencesManager + ProfileSettingsScreen). All 6 will be in the PR after push.
+- **kingdonb/mecris main** still at `56dc719` — no new upstream commits.
+- **yebyen:main is 6 commits ahead of kingdonb:main**: a26b53b (red), cc3336e (green), d8386af (archive-prev), 4cdabbb (red ProfilePrefs), 9c905e0 (green ProfilePrefs), 3e24f83 (feat ProfileSettings).
+- **pr-test NOT YET dispatched for new commits**: last successful pr-test (run 24531480498) only covered triggerReminders, not ProfilePreferencesManager. New dispatch needed after push.
 
 ## Verified This Session
-- [x] **PR #187 opened**: kingdonb/mecris#187 `feat(android): triggerReminders pulse when MCP is dark`.
-- [x] **pr-test passed**: run 24531480498 — Python ✅, Android ✅, Rust ✅.
-- [x] **2 new CooperativeWorkerTest cases** confirmed passing in Android test suite.
-- [x] **Plan yebyen/mecris#201 complete**: closed.
+- [x] **kingdonb/mecris#180 Rust SQL ORDER BY**: already present in both repos at line 1242 of lib.rs — `ORDER BY start_time ASC`. Bug is fixed.
+- [x] **HealthConnectManager preferred_health_source**: already reads from SharedPreferences (line 158). The fix was dead code — no UI to set the value.
+- [x] **ProfilePreferencesManager.kt**: `mecris-go-project/app/src/main/java/com/mecris/go/profile/ProfilePreferencesManager.kt` — get/set for `preferred_health_source`, `phone_number`, `beeminder_user` from `mecris_app_prefs`.
+- [x] **ProfilePreferencesManagerTest**: 8 unit tests (MockK pattern), committed `4cdabbb`.
+- [x] **ProfileSettingsScreen composable**: OutlinedTextField for each pref, Save button, wired to Person icon in top bar, committed `3e24f83`.
+- [x] **Plan issues closed**: yebyen/mecris#202 (already-fixed Rust ORDER BY), yebyen/mecris#203 commented with progress.
 
 ## Pending Verification (Next Session)
+- [ ] **Dispatch pr-test for kingdonb/mecris#187** after workflow pushes yebyen:main. Expected: Python 461 passed (5 skipped), Rust 99 passed, Android BUILD SUCCESSFUL including 8 new `ProfilePreferencesManagerTest` cases + 2 CooperativeWorkerTest cases.
 - [ ] **kingdonb/mecris#187 merged?** Check if kingdonb has merged. If yes: sync yebyen with `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
 - [ ] **Configure internal_api_key in Fermyon Cloud**: Set `internal_api_key = "<secret>"` in runtime-config; update Akamai cron `curl` calls with `X-Internal-Api-Key: <secret>`. This activates the guard. (Needs human with Fermyon access.)
-- [ ] **Run 005_autonomous_sync_consent.sql against live Neon**: `psql $NEON_DB_URL -f scripts/migrations/005_autonomous_sync_consent.sql`. Adds `autonomous_sync_enabled` and `last_autonomous_sync` columns to `users` table. (Needs human with NEON_DB_URL.)
+- [ ] **Run 005_autonomous_sync_consent.sql against live Neon**: `psql $NEON_DB_URL -f scripts/migrations/005_autonomous_sync_consent.sql`. (Needs human with NEON_DB_URL.)
 - [ ] **Confirm Akamai cron jobs firing**: Check Akamai logs for `trigger-reminders`, `failover-sync-edt`, `failover-sync-est` executions.
 - [ ] **Twilio webhook Phase 2 live E2E**: Requires Twilio variables in Fermyon Cloud.
-- [ ] **Multi-Tenancy — Android UI Gaps**: Add "log out" button, phone/location settings, preferred health source. Tracked in kingdonb/mecris#168.
+- [ ] **Multi-Tenancy — Android UI Gaps**: Add "log out" button, location/timezone settings. Tracked in kingdonb/mecris#168.
 - [ ] **Rust test gap (workflow fix)**: Apply fix from yebyen/mecris#142. Needs `workflow` PAT scope — must be applied by kingdonb.
 - [ ] **Multiplier Sync Validation**: Verify Android Review Pump lever updates `pump_multiplier` in Neon.
 
@@ -27,12 +31,14 @@
   - `/internal/failover-sync` (POST): Now uses `handle_failover_sync_post()` — per-user consent flag + `last_autonomous_sync` tracking. Guarded by `internal_api_key` Spin variable (backwards compat: no key = allow all).
   - `/internal/trigger-reminders` (POST): Sends reminders only to users with `autonomous_sync_enabled = true`. Guarded by same key. Android now also calls this as best-effort pulse when MCP is dark.
 - **triggerReminders design**: `SyncServiceApi.triggerReminders()` sends no auth header — Rust endpoint is gated by `X-Internal-Api-Key` only; with key unset (current), all callers are allowed. When key is set in Fermyon Cloud, only Akamai cron will have the key; Android pulse will gracefully fail with 401 (caught + logged).
+- **ProfilePreferencesManager**: Reads/writes `mecris_app_prefs` SharedPreferences. Keys: `preferred_health_source`, `phone_number`, `beeminder_user`. Same SharedPreferences name as `HealthConnectManager` so both see the same value.
+- **preferred_health_source flow**: User sets it in ProfileSettingsScreen → SharedPreferences → HealthConnectManager reads it on next `fetchRecentWalkData()` → AggregateRequest with `dataOriginFilter` set to that package name.
 - **New migration**: `005_autonomous_sync_consent.sql` — adds `autonomous_sync_enabled BOOLEAN DEFAULT false` and `last_autonomous_sync TIMESTAMPTZ` to `users` table. Must run before live consent flag is effective.
 - **Rust 99 tests**: 95 original + 4 new `is_autonomous_sync_allowed` tests. `internal_api_key_ok` tests also present (5 tests).
 - Spin Cron trigger is **DISABLED** in `spin.toml` — do not re-enable.
 - `MECRIS_MODE=standalone` bypasses JWKS for local dev; `MECRIS_MODE=cloud` enforces RSA verification.
 - `MASTER_ENCRYPTION_KEY` must be a 64-char hex string (32-byte AES-256 key).
-- **Classic PAT scope**: `GITHUB_CLASSIC_PAT` has `repo` scope ONLY — no `workflow` scope.
+- **Classic PAT scope**: `GITHUB_CLASSIC_PAT` has `repo` scope ONLY — no `workflow` scope, no `read:org` (can't use `gh pr edit`).
 - **Fine-grained PAT**: `GITHUB_TOKEN` scoped to yebyen/mecris only. Cannot create PRs on kingdonb/mecris — use `gh pr create` with `GITHUB_CLASSIC_PAT`.
 - **NEXT_SESSION.md merge conflict is permanently fixed**: `.gitattributes merge=union` on yebyen/mecris:main.
 - **Python venv not present in bot runner**: Validate Python tests via pr-test workflow only.

--- a/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
@@ -22,8 +22,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import com.mecris.go.profile.ProfilePreferencesManager
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -261,6 +265,7 @@ fun MecrisDashboard(
     
     // UI State
     var showSystemHealth by remember { mutableStateOf(false) }
+    var showProfileSettings by remember { mutableStateOf(false) }
     
     // Lifecycle listener to refresh on resume (with 30s debounce to prevent loops)
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
@@ -288,7 +293,10 @@ fun MecrisDashboard(
     var collectGpsRoutes by remember { mutableStateOf(true) }
 
     // Navigation: Handle system back press
-    BackHandler(enabled = showSystemHealth) {
+    BackHandler(enabled = showProfileSettings) {
+        showProfileSettings = false
+    }
+    BackHandler(enabled = showSystemHealth && !showProfileSettings) {
         showSystemHealth = false
     }
 
@@ -489,7 +497,16 @@ fun MecrisDashboard(
             TopAppBar(
                 title = { Text("MECRIS NEURAL LINK", letterSpacing = 2.sp, fontWeight = FontWeight.Black) },
                 actions = {
-                    IconButton(onClick = { showSystemHealth = !showSystemHealth }) {
+                    IconButton(onClick = {
+                        showProfileSettings = !showProfileSettings
+                        if (showProfileSettings) showSystemHealth = false
+                    }) {
+                        Icon(Icons.Default.Person, contentDescription = "Profile Settings")
+                    }
+                    IconButton(onClick = {
+                        showSystemHealth = !showSystemHealth
+                        if (showSystemHealth) showProfileSettings = false
+                    }) {
                         Icon(if (showSystemHealth) Icons.Default.Info else Icons.Default.Settings, contentDescription = "System Health")
                     }
                     IconButton(onClick = { forceSync() }, enabled = !isLoading) {
@@ -510,7 +527,9 @@ fun MecrisDashboard(
                 .verticalScroll(rememberScrollState())
                 .padding(16.dp)
         ) {
-            if (showSystemHealth) {
+            if (showProfileSettings) {
+                ProfileSettingsScreen(context = context)
+            } else if (showSystemHealth) {
                 SystemHealthScreen(
                     auth = auth,
                     authState = authState,
@@ -1523,9 +1542,82 @@ fun GoalStatusIcon(label: String, met: Boolean) {
         Box(modifier = Modifier.padding(4.dp), contentAlignment = Alignment.Center) {
             Text(
                 text = label, 
-                fontSize = 14.sp, 
+                fontSize = 14.sp,
                 modifier = Modifier.alpha(if (met) 1f else 0.4f)
             )
         }
+    }
+}
+
+@Composable
+fun ProfileSettingsScreen(context: android.content.Context) {
+    val manager = remember { ProfilePreferencesManager(context) }
+
+    var preferredSource by remember { mutableStateOf(manager.getPreferredHealthSource() ?: "") }
+    var phoneNumber by remember { mutableStateOf(manager.getPhoneNumber() ?: "") }
+    var beeminderUser by remember { mutableStateOf(manager.getBeeminderUser() ?: "") }
+    var saveStatus by remember { mutableStateOf("") }
+
+    Text(
+        text = "PROFILE SETTINGS",
+        style = MaterialTheme.typography.titleMedium,
+        color = Color.White,
+        fontWeight = FontWeight.Bold
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text("Health Connect Source Filter", color = Color.Gray, style = MaterialTheme.typography.labelMedium)
+    Text(
+        "Package name of your preferred step source (e.g. com.google.android.apps.fitness). Leave blank to use Health Connect's default deduplication.",
+        color = Color.Gray,
+        style = MaterialTheme.typography.bodySmall
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    OutlinedTextField(
+        value = preferredSource,
+        onValueChange = { preferredSource = it },
+        label = { Text("Preferred Health Source") },
+        placeholder = { Text("com.google.android.apps.fitness") },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+    Text("Phone Number (E.164 format)", color = Color.Gray, style = MaterialTheme.typography.labelMedium)
+    OutlinedTextField(
+        value = phoneNumber,
+        onValueChange = { phoneNumber = it },
+        label = { Text("Phone Number") },
+        placeholder = { Text("+15551234567") },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone)
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+    Text("Beeminder Username", color = Color.Gray, style = MaterialTheme.typography.labelMedium)
+    OutlinedTextField(
+        value = beeminderUser,
+        onValueChange = { beeminderUser = it },
+        label = { Text("Beeminder User") },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true
+    )
+
+    Spacer(modifier = Modifier.height(24.dp))
+    Button(
+        onClick = {
+            manager.setPreferredHealthSource(preferredSource)
+            manager.setPhoneNumber(phoneNumber)
+            manager.setBeeminderUser(beeminderUser)
+            saveStatus = "Saved"
+        },
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text("SAVE")
+    }
+    if (saveStatus.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(saveStatus, color = Color(0xFF00C853))
     }
 }

--- a/mecris-go-project/app/src/main/java/com/mecris/go/health/WalkHeuristicsWorker.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/health/WalkHeuristicsWorker.kt
@@ -58,10 +58,18 @@ class WalkHeuristicsWorker @JvmOverloads constructor(
                     // Cooperative Cloud Sync: If MCP is dark and we haven't triggered in 2 hours
                     val twoHoursAgo = Instant.now().minusSeconds(7200).toEpochMilli()
                     if (body?.mcp_server_active == false && lastCloudSyncTrigger < twoHoursAgo) {
-                        Log.w("WalkHeuristicsWorker", "MCP Server is DARK. Triggering Autonomous Cloud Sync.")
+                        Log.w("WalkHeuristicsWorker", "MCP Server is DARK. Triggering Autonomous Cloud Sync + Reminders.")
                         val syncResponse = syncApi.triggerCloudSync("Bearer $token")
                         if (!syncResponse.isSuccessful) {
                             throw retrofit2.HttpException(syncResponse)
+                        }
+                        try {
+                            val remindersResponse = syncApi.triggerReminders()
+                            if (!remindersResponse.isSuccessful) {
+                                Log.w("WalkHeuristicsWorker", "Reminders trigger returned: ${remindersResponse.code()}")
+                            }
+                        } catch (e: Exception) {
+                            Log.e("WalkHeuristicsWorker", "Reminders trigger failed: ${e.message}")
                         }
                         prefs.edit().putLong("last_cloud_sync_trigger", Instant.now().toEpochMilli()).apply()
                     }

--- a/mecris-go-project/app/src/main/java/com/mecris/go/profile/ProfilePreferencesManager.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/profile/ProfilePreferencesManager.kt
@@ -1,0 +1,45 @@
+package com.mecris.go.profile
+
+import android.content.Context
+
+private const val PREFS_NAME = "mecris_app_prefs"
+private const val KEY_PREFERRED_HEALTH_SOURCE = "preferred_health_source"
+private const val KEY_PHONE_NUMBER = "phone_number"
+private const val KEY_BEEMINDER_USER = "beeminder_user"
+
+class ProfilePreferencesManager(private val context: Context) {
+
+    private val prefs by lazy {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    fun getPreferredHealthSource(): String? = prefs.getString(KEY_PREFERRED_HEALTH_SOURCE, null)
+
+    fun setPreferredHealthSource(value: String) {
+        val trimmed = value.trim()
+        prefs.edit().apply {
+            if (trimmed.isBlank()) remove(KEY_PREFERRED_HEALTH_SOURCE) else putString(KEY_PREFERRED_HEALTH_SOURCE, trimmed)
+            apply()
+        }
+    }
+
+    fun getPhoneNumber(): String? = prefs.getString(KEY_PHONE_NUMBER, null)
+
+    fun setPhoneNumber(value: String) {
+        val trimmed = value.trim()
+        prefs.edit().apply {
+            if (trimmed.isBlank()) remove(KEY_PHONE_NUMBER) else putString(KEY_PHONE_NUMBER, trimmed)
+            apply()
+        }
+    }
+
+    fun getBeeminderUser(): String? = prefs.getString(KEY_BEEMINDER_USER, null)
+
+    fun setBeeminderUser(value: String) {
+        val trimmed = value.trim()
+        prefs.edit().apply {
+            if (trimmed.isBlank()) remove(KEY_BEEMINDER_USER) else putString(KEY_BEEMINDER_USER, trimmed)
+            apply()
+        }
+    }
+}

--- a/mecris-go-project/app/src/main/java/com/mecris/go/sync/SyncServiceApi.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/sync/SyncServiceApi.kt
@@ -36,6 +36,9 @@ interface SyncServiceApi {
         @Header("Authorization") authHeader: String
     ): retrofit2.Response<SyncResponse>
 
+    @POST("internal/trigger-reminders")
+    suspend fun triggerReminders(): retrofit2.Response<SyncResponse>
+
     @POST("heartbeat")
     suspend fun sendHeartbeat(
         @Header("Authorization") authHeader: String,

--- a/mecris-go-project/app/src/test/java/com/mecris/go/health/CooperativeWorkerTest.kt
+++ b/mecris-go-project/app/src/test/java/com/mecris/go/health/CooperativeWorkerTest.kt
@@ -81,4 +81,47 @@ class CooperativeWorkerTest {
         coVerify(exactly = 0) { syncApi.triggerCloudSync(any()) }
         }
 
+        @Test
+        fun `worker triggers reminders when MCP is dark`() = runBlocking {
+        // GIVEN: MCP is reported as NOT active
+        coEvery { syncApi.sendHeartbeat(any(), any()) } returns retrofit2.Response.success(
+            HeartbeatResponseDto("ok", mcp_server_active = false)
+        )
+        coEvery { syncApi.triggerCloudSync(any()) } returns retrofit2.Response.success(
+            SyncResponse("ok", "cloud sync triggered")
+        )
+        coEvery { syncApi.triggerReminders() } returns retrofit2.Response.success(
+            SyncResponse("ok", "reminders triggered")
+        )
+        coEvery { syncApi.getLanguages(any()) } returns retrofit2.Response.success(
+            com.mecris.go.sync.LanguagesResponseDto(emptyList())
+        )
+
+        val worker = WalkHeuristicsWorker(context, workerParams, pocketIdAuth, syncApi)
+
+        worker.doWork()
+
+        // VERIFY: Both cloud sync AND reminders were triggered
+        coVerify(exactly = 1) { syncApi.triggerCloudSync(any()) }
+        coVerify(exactly = 1) { syncApi.triggerReminders() }
+        }
+
+        @Test
+        fun `worker DOES NOT trigger reminders when MCP is active`() = runBlocking {
+        // GIVEN: MCP is reported as active
+        coEvery { syncApi.sendHeartbeat(any(), any()) } returns retrofit2.Response.success(
+            HeartbeatResponseDto("ok", mcp_server_active = true)
+        )
+        coEvery { syncApi.getLanguages(any()) } returns retrofit2.Response.success(
+            com.mecris.go.sync.LanguagesResponseDto(emptyList())
+        )
+
+        val worker = WalkHeuristicsWorker(context, workerParams, pocketIdAuth, syncApi)
+
+        worker.doWork()
+
+        // VERIFY: Reminders were NOT triggered
+        coVerify(exactly = 0) { syncApi.triggerReminders() }
+        }
+
 }

--- a/mecris-go-project/app/src/test/java/com/mecris/go/profile/ProfilePreferencesManagerTest.kt
+++ b/mecris-go-project/app/src/test/java/com/mecris/go/profile/ProfilePreferencesManagerTest.kt
@@ -1,0 +1,84 @@
+package com.mecris.go.profile
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.mockk.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class ProfilePreferencesManagerTest {
+
+    private val context = mockk<Context>(relaxed = true)
+    private val sharedPrefs = mockk<SharedPreferences>()
+    private val prefsEditor = mockk<SharedPreferences.Editor>(relaxed = true)
+
+    @Before
+    fun setup() {
+        every { context.getSharedPreferences("mecris_app_prefs", Context.MODE_PRIVATE) } returns sharedPrefs
+        every { sharedPrefs.edit() } returns prefsEditor
+        every { prefsEditor.putString(any(), any()) } returns prefsEditor
+        every { prefsEditor.remove(any()) } returns prefsEditor
+    }
+
+    @Test
+    fun `getPreferredHealthSource returns null when not set`() {
+        every { sharedPrefs.getString("preferred_health_source", null) } returns null
+        val manager = ProfilePreferencesManager(context)
+        assertNull(manager.getPreferredHealthSource())
+    }
+
+    @Test
+    fun `getPreferredHealthSource returns stored value`() {
+        every { sharedPrefs.getString("preferred_health_source", null) } returns "com.google.android.apps.fitness"
+        val manager = ProfilePreferencesManager(context)
+        assertEquals("com.google.android.apps.fitness", manager.getPreferredHealthSource())
+    }
+
+    @Test
+    fun `setPreferredHealthSource writes to SharedPreferences`() {
+        val manager = ProfilePreferencesManager(context)
+        manager.setPreferredHealthSource("com.samsung.health")
+        verify { prefsEditor.putString("preferred_health_source", "com.samsung.health") }
+        verify { prefsEditor.apply() }
+    }
+
+    @Test
+    fun `setPreferredHealthSource with blank value removes the key`() {
+        val manager = ProfilePreferencesManager(context)
+        manager.setPreferredHealthSource("   ")
+        verify { prefsEditor.remove("preferred_health_source") }
+        verify { prefsEditor.apply() }
+    }
+
+    @Test
+    fun `getPhoneNumber returns null when not set`() {
+        every { sharedPrefs.getString("phone_number", null) } returns null
+        val manager = ProfilePreferencesManager(context)
+        assertNull(manager.getPhoneNumber())
+    }
+
+    @Test
+    fun `setPhoneNumber writes to SharedPreferences`() {
+        val manager = ProfilePreferencesManager(context)
+        manager.setPhoneNumber("+15551234567")
+        verify { prefsEditor.putString("phone_number", "+15551234567") }
+        verify { prefsEditor.apply() }
+    }
+
+    @Test
+    fun `getBeeminderUser returns null when not set`() {
+        every { sharedPrefs.getString("beeminder_user", null) } returns null
+        val manager = ProfilePreferencesManager(context)
+        assertNull(manager.getBeeminderUser())
+    }
+
+    @Test
+    fun `setBeeminderUser writes to SharedPreferences`() {
+        val manager = ProfilePreferencesManager(context)
+        manager.setBeeminderUser("alice")
+        verify { prefsEditor.putString("beeminder_user", "alice") }
+        verify { prefsEditor.apply() }
+    }
+}

--- a/session_log.md
+++ b/session_log.md
@@ -1465,3 +1465,13 @@ This document summarizes the collaborative debugging session to establish a func
 **Skipped**: Nothing — plan fully executed.
 
 **Next**: Check if kingdonb merged PR #187; sync yebyen if so. Configure internal_api_key in Fermyon Cloud + run 005_autonomous_sync_consent.sql against Neon (human actions required).
+
+## 2026-04-16 🏛️ — Profile Settings screen + #180 investigation — yebyen/mecris#203
+
+**Planned**: yebyen/mecris#202 (closed immediately) — Fix non-deterministic Rust DB query `ORDER BY`; discovered already fixed in both repos. yebyen/mecris#203 — Android Profile Settings screen to make `preferred_health_source` settable.
+
+**Done**: Oriented — PR #187 still open (kingdonb/mecris main unchanged). Investigated kingdonb/mecris#180: Rust SQL `ORDER BY start_time ASC` already present at lib.rs line 1242; Android `preferred_health_source` source-filter already coded in HealthConnectManager.kt line 158 but was dead code (no UI). Created ProfilePreferencesManager.kt (get/set for preferred_health_source, phone_number, beeminder_user via mecris_app_prefs SharedPrefs). Added 8-test ProfilePreferencesManagerTest (MockK pattern). Added ProfileSettingsScreen composable + Person icon nav toggle to MecrisDashboard. Three commits: 4cdabbb (red), 9c905e0 (green), 3e24f83 (feat).
+
+**Skipped**: pr-test dispatch — push constraint. Can't comment on kingdonb/mecris#180 (token scope). Can't `gh pr edit` #187 (CLASSIC_PAT lacks read:org). PR #187 will auto-include all 6 yebyen:main commits on push.
+
+**Next**: Dispatch pr-test for kingdonb/mecris#187 after push — expect Python 461, Rust 99, Android BUILD_SUCCESSFUL + 8 new ProfilePreferencesManagerTest + 2 CooperativeWorkerTest.

--- a/session_log.md
+++ b/session_log.md
@@ -1445,3 +1445,13 @@ This document summarizes the collaborative debugging session to establish a func
 **Skipped**: pr-test dispatch — push constraint (must wait for CI to push `4d6e9d6` to GitHub). Security-only PR — deemed unnecessary since PR #186 already covers the additions cleanly.
 
 **Next**: Dispatch pr-test for kingdonb/mecris#186 (expect 461 Python + 99 Rust). Run `005_autonomous_sync_consent.sql` against live Neon to activate consent flag in prod.
+
+## 2026-04-16 🏛️ — Android pulse: triggerReminders added to WalkHeuristicsWorker — yebyen/mecris#200
+
+**Planned**: yebyen/mecris#200 — Add `triggerReminders()` to `SyncServiceApi.kt` and call it in `WalkHeuristicsWorker` when `mcp_server_active == false`; add 2 CooperativeWorkerTest cases; refs kingdonb/mecris#168.
+
+**Done**: Oriented — PR #186 merged, yebyen==kingdonb (0/0), no tagged issues, #168 task unimplemented. Created plan yebyen/mecris#200. Red (`a26b53b`): added `worker triggers reminders when MCP is dark` + `worker DOES NOT trigger reminders when MCP is active` to CooperativeWorkerTest. Green (`cc3336e`): added `@POST("internal/trigger-reminders") suspend fun triggerReminders()` to SyncServiceApi (no auth header — key guard backwards-compat); updated WalkHeuristicsWorker to call triggerReminders() after triggerCloudSync() when dark (failures caught + logged, not thrown).
+
+**Skipped**: pr-test dispatch — push constraint (commits land on GitHub after workflow ends). Opening PR to kingdonb — deferred to next session.
+
+**Next**: Open PR yebyen:main → kingdonb:main carrying triggerReminders; dispatch pr-test to confirm 461 Python + 99 Rust + Android tests (including 2 new CooperativeWorkerTest) pass.

--- a/session_log.md
+++ b/session_log.md
@@ -1455,3 +1455,13 @@ This document summarizes the collaborative debugging session to establish a func
 **Skipped**: pr-test dispatch — push constraint (commits land on GitHub after workflow ends). Opening PR to kingdonb — deferred to next session.
 
 **Next**: Open PR yebyen:main → kingdonb:main carrying triggerReminders; dispatch pr-test to confirm 461 Python + 99 Rust + Android tests (including 2 new CooperativeWorkerTest) pass.
+
+## 2026-04-16 🏛️ — PR opened kingdonb/mecris#187 (triggerReminders) + pr-test ✅ — yebyen/mecris#201
+
+**Planned**: yebyen/mecris#201 — Open PR yebyen:main → kingdonb:main carrying triggerReminders feature (3 commits); dispatch pr-test; expect 461 Python + 99 Rust + Android including 2 new CooperativeWorkerTest cases.
+
+**Done**: Oriented — yebyen 3 commits ahead of kingdonb (a26b53b red, cc3336e green, d8386af archive). Opened kingdonb/mecris#187 `feat(android): triggerReminders pulse when MCP is dark` via `gh pr create` with GITHUB_CLASSIC_PAT (GITHUB_TOKEN can't write to kingdonb/mecris). Dispatched pr-test run 24531480498. All three suites passed: Python 461 (5 skipped), Android BUILD SUCCESSFUL (24 tasks, CooperativeWorkerTest ✅), Rust 99 passed 0 failed.
+
+**Skipped**: Nothing — plan fully executed.
+
+**Next**: Check if kingdonb merged PR #187; sync yebyen if so. Configure internal_api_key in Fermyon Cloud + run 005_autonomous_sync_consent.sql against Neon (human actions required).


### PR DESCRIPTION
## Summary

- Adds `SyncServiceApi.triggerReminders()` — `@POST("internal/trigger-reminders")` with no auth header (Rust endpoint gated by `X-Internal-Api-Key` only)
- `WalkHeuristicsWorker` calls `triggerReminders()` alongside `triggerCloudSync()` when `mcp_server_active == false` (MCP is dark)
- 2 new Android unit tests: `worker triggers reminders when MCP is dark` and `worker DOES NOT trigger reminders when MCP is active`

## Design

When MCP is dark, the Android worker fires a best-effort pulse to `/internal/trigger-reminders`. This is intentionally unauthenticated from Android — the Rust endpoint is gated only by `X-Internal-Api-Key`. With the key unset (current production), all callers are allowed. Once the key is set in Fermyon Cloud, only Akamai cron will have it; Android pulse will gracefully fail with 401 (caught and logged).

## Test plan
- [ ] Python: 461 passed (5 skipped) — baseline from run 24509446714
- [ ] Rust: 99 passed — 95 original + 4 `is_autonomous_sync_allowed` tests
- [ ] Android: CooperativeWorkerTest passes including 2 new cases

## Related
- Closes yebyen/mecris#201 (plan issue)
- Rust endpoint implemented in kingdonb/mecris#185 (already merged)
- Akamai cron trigger: `/internal/trigger-reminders` already live

🤖 Generated with [Claude Code](https://claude.com/claude-code)