### PR TITLE
fix(android): goal-specific LLM fallback text in SovereignBrain + log out button

### DIFF
--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,20 +1,22 @@
-# Next Session: Dispatch pr-test for SovereignBrain fallback fix (yebyen/mecris#205)
+# Next Session: Re-run pr-test for kingdonb/mecris#189 (Android fix committed, needs push+validate)
 
 ## Current Status (2026-04-17)
-- **SovereignBrain fallback fix committed**: `SovereignBrain.goalSpecificFallback()` companion object added (commit `59c1bc5`). Arabic/Walk nags now get goal-appropriate fallback text when Gemini Nano inference fails. Moussaka fallback preserved for GREEK only.
-- **4 unit tests added**: `SovereignBrainFallbackTest` (commit `ee2126e`) — Arabic, Walk, GREEK, and unknown goal cases all covered. Tests will be validated via pr-test CI.
-- **Repos**: yebyen/mecris is 2 commits ahead of kingdonb/mecris main (workflow will push at session end).
-- **kingdonb/mecris#168 closed**: Phase 4 (Profile Page & Heartbeat) fully complete as of 2026-04-17.
+- **PR open**: kingdonb/mecris#189 — yebyen:main → kingdonb:main (SovereignBrain fallback fix + log out button). 4 commits ahead of kingdonb:main now (was 3; green fix added this session).
+- **Android regression fixed**: `5946d4e` had changed `Editor.apply()` → `Editor.commit()` in `ProfilePreferencesManager.kt`, breaking 4 tests in `ProfilePreferencesManagerTest`. Fixed in commit `57acd70` (green: restore apply()). Fix is local — pushed by workflow at session end.
+- **pr-test result (run #24564190870)**: ✅ Python 461 passed (5 skipped) | ✅ Rust 102 passed | ❌ Android 5 failed (all in ProfilePreferencesManagerTest, pre-existing regression from 5946d4e).
+- **SovereignBrainFallbackTest**: Likely passed (4 tests), confirmed indirectly — the Android failure report only named ProfilePreferencesManagerTest failures.
 
 ## Verified This Session
-- [x] **Root cause identified**: `SovereignBrain.kt:72` used hard-coded Greek moussaka fallback for ALL goals — caused Arabic nags at 8am to show "The moussaka is waiting" when on-device LLM inference failed.
-- [x] **TDG complete**: Red (`ee2126e`) + Green (`59c1bc5`) committed.
-- [x] **Plan issue yebyen/mecris#205**: Commented with work summary; closed by archive.
-- [x] **yebyen/mecris#204 (log out) and kingdonb/mecris#168 (Phase 4)**: Both closed this session cycle.
+- [x] **PR opened**: kingdonb/mecris#189 created from yebyen:main → kingdonb:main
+- [x] **pr-test dispatched and completed**: run #24564190870, Python/Rust clean
+- [x] **Android root cause identified**: `commit()` vs `apply()` mismatch in ProfilePreferencesManager.kt (5946d4e regression)
+- [x] **Green fix committed**: `57acd70` — ProfilePreferencesManager setters now use `editor.apply()`
+- [x] **Plan issue yebyen/mecris#206**: commented with root cause + fix details; closed by archive
 
 ## Pending Verification (Next Session)
-- [ ] **Open PR to kingdonb/mecris**: After workflow pushes yebyen:main (2 commits ahead), open PR for SovereignBrain fallback fix + log out button. Command: `GH_TOKEN="$GITHUB_CLASSIC_PAT" gh pr create --repo kingdonb/mecris --head yebyen:main --base main --title "fix(android): goal-specific LLM fallback text in SovereignBrain + log out button"`.
-- [ ] **Dispatch pr-test**: After PR is opened, dispatch pr-test to validate `SovereignBrainFallbackTest` (4 cases) alongside existing Android suite. Expected: Python 461 passed (5 skipped), Rust 99 passed, Android BUILD SUCCESSFUL including `SovereignBrainFallbackTest`.
+- [ ] **Re-run pr-test for kingdonb/mecris#189**: After workflow pushes the green fix (57acd70), dispatch pr-test. Command: `curl -X POST -H "Authorization: Bearer $GITHUB_CLASSIC_PAT" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" -d '{"ref":"main","inputs":{"pr_number":"189","upstream_repo":"kingdonb/mecris"}}' https://api.github.com/repos/yebyen/mecris/actions/workflows/pr-test.yml/dispatches`. Expected: Python 461 passed, Rust 102 passed, Android BUILD SUCCESSFUL (24 tests, 0 failed including SovereignBrainFallbackTest 4 cases and ProfilePreferencesManagerTest 8 cases).
+- [ ] **Identify 5th failing Android test**: pr-test showed 5 failed but ProfilePreferencesManagerTest only has 4 `apply()` verify checks. If re-run still shows a 5th failure, investigate which test class.
+- [ ] **Merge kingdonb/mecris#189**: After pr-test passes, request merge.
 - [ ] **Secondary DelayedNagWorker message bug**: `DelayedNagWorker.kt:135` message "The moussaka is waiting, but the cards come first" always implies Arabic is undone, even when `arabicCleared = true` fires it. Harmless but misleading. Consider fixing in a future session.
 - [ ] **Configure internal_api_key in Fermyon Cloud**: Set `internal_api_key = "<secret>"` in runtime-config; update Akamai cron `curl` calls with `X-Internal-Api-Key: <secret>`. (Needs human with Fermyon access.)
 - [ ] **Twilio webhook Phase 2 live E2E**: Requires Twilio variables in Fermyon Cloud.
@@ -24,9 +26,9 @@
 - **Akamai Functions (Trial)**: Persistent cron triggers for reminders and failover syncing.
   - `/internal/failover-sync` (GET/POST): Per-user consent flag + `last_autonomous_sync` tracking. Guarded by `internal_api_key` Spin variable (backwards compat: no key = allow all).
   - `/internal/trigger-reminders` (GET/POST): Sends reminders only to users with `autonomous_sync_enabled = true`. Guarded by same key.
-- **ProfilePreferencesManager**: Reads/writes `mecris_app_prefs` SharedPreferences. Keys: `preferred_health_source`, `phone_number`, `beeminder_user`.
+- **ProfilePreferencesManager**: Reads/writes `mecris_app_prefs` SharedPreferences. Keys: `preferred_health_source`, `phone_number`, `beeminder_user`. Setters now use `editor.apply()` (async, non-blocking) — restored from regression.
 - **PocketIdAuth.signOut()**: Clears `auth_prefs`/`auth_state_json` key. Does NOT clear profile prefs (persist across re-login — by design).
-- **SovereignBrain**: Local LLM via Google AI Edge SDK (Gemini Nano/AICore). `generateNarrativeDirective()` now uses `goalSpecificFallback(targetGoal)` when model returns null.
+- **SovereignBrain**: Local LLM via Google AI Edge SDK (Gemini Nano/AICore). `generateNarrativeDirective()` uses `goalSpecificFallback(targetGoal)` when model returns null.
 - **DelayedNagWorker time guards**: Arabic fires 08:00–20:00; Walk fires 08:00+ (with weather/dark checks); GREEK fires 17:00–22:30 (isMoussakaHour), with Arabic-cleared override after 20:00.
 - **Spin Cron trigger**: DISABLED in `spin.toml` — do not re-enable.
 - **MECRIS_MODE=standalone** bypasses JWKS for local dev; `MECRIS_MODE=cloud` enforces RSA verification.
@@ -35,6 +37,6 @@
 - **Fine-grained PAT**: `GITHUB_TOKEN` scoped to yebyen/mecris only. Cannot create PRs on kingdonb/mecris — use `GITHUB_CLASSIC_PAT`.
 - **NEXT_SESSION.md merge conflict is permanently fixed**: `.gitattributes merge=union` on yebyen/mecris:main.
 - **Python venv not present in bot runner**: Validate Python tests via pr-test workflow only.
-- **Python test count baseline**: 461 passed (5 skipped). Rust: 99 passed. Android: BUILD SUCCESSFUL.
-- **Rust satellite crates**: 99 tests in sync-service, 28 in boris-fiona-walker, others not in CI yet.
+- **Python test count baseline**: 461 passed (5 skipped). Rust: 102 passed (was 99, grew this cycle). Android: 24 tests, 5 failed (will be 0 failed after 57acd70 is included).
+- **Rust satellite crates**: 99+ tests in sync-service, 28 in boris-fiona-walker, others not in CI yet.
 - **autonomous_sync_enabled**: DB flag per user (`users` table). Controls which users get processed by `/internal/trigger-reminders`. Default `false` — user must opt in.

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,21 +1,21 @@
-# Next Session: Open PR + pr-test for Log Out button (yebyen/mecris#204)
+# Next Session: Dispatch pr-test for SovereignBrain fallback fix (yebyen/mecris#205)
 
 ## Current Status (2026-04-17)
-- **PR #187 merged**: kingdonb merged yebyen's triggerReminders + ProfileSettingsScreen PR on 2026-04-16. yebyen/mecris is 0 commits behind kingdonb/mecris.
-- **Log Out button built**: `PocketIdAuth.signOut()` + `ProfileSettingsScreen` log out button committed locally (commits 00fdaa4 + d8535e3). Workflow will push to GitHub this session end.
-- **Test Baseline**: Python: 461 passed (5 skipped). Rust: 99 passed. Android: BUILD SUCCESSFUL + 8 `ProfilePreferencesManagerTest` + 4 `CooperativeWorkerTest`. New `PocketIdAuthTest` (1 case) added this session — needs CI validation.
-- **PR to kingdonb/mecris blocked**: Can't open PR until commits are pushed by workflow.
+- **SovereignBrain fallback fix committed**: `SovereignBrain.goalSpecificFallback()` companion object added (commit `59c1bc5`). Arabic/Walk nags now get goal-appropriate fallback text when Gemini Nano inference fails. Moussaka fallback preserved for GREEK only.
+- **4 unit tests added**: `SovereignBrainFallbackTest` (commit `ee2126e`) — Arabic, Walk, GREEK, and unknown goal cases all covered. Tests will be validated via pr-test CI.
+- **Repos**: yebyen/mecris is 2 commits ahead of kingdonb/mecris main (workflow will push at session end).
+- **kingdonb/mecris#168 closed**: Phase 4 (Profile Page & Heartbeat) fully complete as of 2026-04-17.
 
 ## Verified This Session
-- [x] **PR #187 merged**: `git fetch kingdonb/mecris main` shows 0 commits behind.
-- [x] **Log out code complete**: `PocketIdAuth.signOut()` clears `auth_state_json` from SharedPreferences, resets `internalAuthState`, emits `AuthState.Idle`. LOG OUT button in `ProfileSettingsScreen` (dark red, full-width) collapses panel and calls `auth.signOut()`.
-- [x] **Red test committed**: `PocketIdAuthTest` — `signOut clears auth token from SharedPreferences and resets state to Idle` using `mockkConstructor(AuthorizationService::class)`.
+- [x] **Root cause identified**: `SovereignBrain.kt:72` used hard-coded Greek moussaka fallback for ALL goals — caused Arabic nags at 8am to show "The moussaka is waiting" when on-device LLM inference failed.
+- [x] **TDG complete**: Red (`ee2126e`) + Green (`59c1bc5`) committed.
+- [x] **Plan issue yebyen/mecris#205**: Commented with work summary; closed by archive.
+- [x] **yebyen/mecris#204 (log out) and kingdonb/mecris#168 (Phase 4)**: Both closed this session cycle.
 
 ## Pending Verification (Next Session)
-- [ ] **Open PR to kingdonb/mecris**: After workflow pushes yebyen:main, open PR for the log out feature. Command: `GH_TOKEN="$GITHUB_CLASSIC_PAT" gh pr create --repo kingdonb/mecris --head yebyen:main --base main --title "feat(android): log out button in ProfileSettingsScreen"`. Closes yebyen/mecris#204.
-- [ ] **Dispatch pr-test for the log out PR**: Expected: Python 461 passed (5 skipped), Rust 99 passed, Android BUILD SUCCESSFUL including new `PocketIdAuthTest` case. Test uses `mockkConstructor(AuthorizationService::class)` — if this fails in CI due to AppAuth constructor mocking, the test needs to be replaced with a simpler approach (e.g., test the SharedPreferences clearing via a different abstraction).
-- [ ] **kingdonb/mecris#168 status**: Log out button addresses the last remaining Android UI gap. Comment on #168 referencing the PR once it's open.
-- [ ] **Android App "Grill-Me" Session**: Investigate "moussaka in the morning" notification issue — logic flaws in Majesty Cake or Review Pump notifications.
+- [ ] **Open PR to kingdonb/mecris**: After workflow pushes yebyen:main (2 commits ahead), open PR for SovereignBrain fallback fix + log out button. Command: `GH_TOKEN="$GITHUB_CLASSIC_PAT" gh pr create --repo kingdonb/mecris --head yebyen:main --base main --title "fix(android): goal-specific LLM fallback text in SovereignBrain + log out button"`.
+- [ ] **Dispatch pr-test**: After PR is opened, dispatch pr-test to validate `SovereignBrainFallbackTest` (4 cases) alongside existing Android suite. Expected: Python 461 passed (5 skipped), Rust 99 passed, Android BUILD SUCCESSFUL including `SovereignBrainFallbackTest`.
+- [ ] **Secondary DelayedNagWorker message bug**: `DelayedNagWorker.kt:135` message "The moussaka is waiting, but the cards come first" always implies Arabic is undone, even when `arabicCleared = true` fires it. Harmless but misleading. Consider fixing in a future session.
 - [ ] **Configure internal_api_key in Fermyon Cloud**: Set `internal_api_key = "<secret>"` in runtime-config; update Akamai cron `curl` calls with `X-Internal-Api-Key: <secret>`. (Needs human with Fermyon access.)
 - [ ] **Twilio webhook Phase 2 live E2E**: Requires Twilio variables in Fermyon Cloud.
 - [ ] **Rust test gap (workflow fix)**: Apply fix from yebyen/mecris#142. Needs `workflow` PAT scope — must be applied by kingdonb.
@@ -23,24 +23,18 @@
 ## Infrastructure Notes
 - **Akamai Functions (Trial)**: Persistent cron triggers for reminders and failover syncing.
   - `/internal/failover-sync` (GET/POST): Per-user consent flag + `last_autonomous_sync` tracking. Guarded by `internal_api_key` Spin variable (backwards compat: no key = allow all).
-  - `/internal/trigger-reminders` (GET/POST): Sends reminders only to users with `autonomous_sync_enabled = true`. Guarded by same key. Android also calls this as best-effort pulse when MCP is dark.
-- **ProfilePreferencesManager**: Reads/writes `mecris_app_prefs` SharedPreferences. Keys: `preferred_health_source`, `phone_number`, `beeminder_user`. Same SharedPreferences name as `HealthConnectManager`.
-- **PocketIdAuth.signOut()**: Clears `auth_prefs`/`auth_state_json` key. Does NOT clear profile prefs (phone, beeminder user persist across re-login — by design).
-- **New migration**: `005_autonomous_sync_consent.sql` — adds `autonomous_sync_enabled BOOLEAN DEFAULT false` and `last_autonomous_sync TIMESTAMPTZ` to `users` table.
-- **Rust 99 tests**: 95 original + 4 new `is_autonomous_sync_allowed` tests.
-- Spin Cron trigger is **DISABLED** in `spin.toml` — do not re-enable.
-- `MECRIS_MODE=standalone` bypasses JWKS for local dev; `MECRIS_MODE=cloud` enforces RSA verification.
-- `MASTER_ENCRYPTION_KEY` must be a 64-char hex string (32-byte AES-256 key).
-- **Classic PAT scope**: `GITHUB_CLASSIC_PAT` has `repo` scope ONLY — no `workflow` scope, no `read:org` (can't use `gh pr edit`).
-- **Fine-grained PAT**: `GITHUB_TOKEN` scoped to yebyen/mecris only. Cannot create PRs on kingdonb/mecris — use `gh pr create` with `GITHUB_CLASSIC_PAT`.
+  - `/internal/trigger-reminders` (GET/POST): Sends reminders only to users with `autonomous_sync_enabled = true`. Guarded by same key.
+- **ProfilePreferencesManager**: Reads/writes `mecris_app_prefs` SharedPreferences. Keys: `preferred_health_source`, `phone_number`, `beeminder_user`.
+- **PocketIdAuth.signOut()**: Clears `auth_prefs`/`auth_state_json` key. Does NOT clear profile prefs (persist across re-login — by design).
+- **SovereignBrain**: Local LLM via Google AI Edge SDK (Gemini Nano/AICore). `generateNarrativeDirective()` now uses `goalSpecificFallback(targetGoal)` when model returns null.
+- **DelayedNagWorker time guards**: Arabic fires 08:00–20:00; Walk fires 08:00+ (with weather/dark checks); GREEK fires 17:00–22:30 (isMoussakaHour), with Arabic-cleared override after 20:00.
+- **Spin Cron trigger**: DISABLED in `spin.toml` — do not re-enable.
+- **MECRIS_MODE=standalone** bypasses JWKS for local dev; `MECRIS_MODE=cloud` enforces RSA verification.
+- **MASTER_ENCRYPTION_KEY**: Must be a 64-char hex string (32-byte AES-256 key).
+- **Classic PAT scope**: `GITHUB_CLASSIC_PAT` has `repo` scope ONLY — no `workflow` scope, no `read:org`.
+- **Fine-grained PAT**: `GITHUB_TOKEN` scoped to yebyen/mecris only. Cannot create PRs on kingdonb/mecris — use `GITHUB_CLASSIC_PAT`.
 - **NEXT_SESSION.md merge conflict is permanently fixed**: `.gitattributes merge=union` on yebyen/mecris:main.
 - **Python venv not present in bot runner**: Validate Python tests via pr-test workflow only.
-- **pr-test.yml push constraint**: Dispatch pr-test ONLY after commits land on GitHub (next session after push).
+- **Python test count baseline**: 461 passed (5 skipped). Rust: 99 passed. Android: BUILD SUCCESSFUL.
 - **Rust satellite crates**: 99 tests in sync-service, 28 in boris-fiona-walker, others not in CI yet.
-- **Rust compile fix pattern**: All branches in `handle_sync_service` that return a value must use explicit `return`.
-- **Test isolation pattern**: Tests that import `mcp_server` must use `sys.modules.pop("mcp_server", None)` + `patch.dict(os.environ, ...)` + `patch("psycopg2.connect")` before importing.
-- **Python test count baseline**: 461 passed (5 skipped) confirmed in pr-test run 24531480498. Akamai E2E test now permanently skipped in CI.
-- **schema.sql budget_tracking schema**: columns are `budget_period_start TEXT NOT NULL`, `budget_period_end TEXT NOT NULL`, `total_budget DOUBLE PRECISION NOT NULL`, `remaining_budget DOUBLE PRECISION NOT NULL`, `user_id UNIQUE REFERENCES users(pocket_id_sub)`.
-- **Upstream sync pattern**: `git fetch https://github.com/kingdonb/mecris.git main && git merge FETCH_HEAD --no-edit`.
-- **internal_api_key Spin variable**: Optional variable — set to activate `/internal/*` endpoint key guard. Header: `X-Internal-Api-Key`. Empty = open (backwards compat).
-- **autonomous_sync_enabled**: DB flag per user (`users` table). Controls which users get processed by `/internal/trigger-reminders` and `/internal/failover-sync`. Default `false` — user must opt in.
+- **autonomous_sync_enabled**: DB flag per user (`users` table). Controls which users get processed by `/internal/trigger-reminders`. Default `false` — user must opt in.

--- a/mecris-go-project/app/src/main/java/com/mecris/go/ai/SovereignBrain.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/ai/SovereignBrain.kt
@@ -13,6 +13,15 @@ import kotlinx.coroutines.withContext
  */
 class SovereignBrain(private val context: Context) {
 
+    companion object {
+        fun goalSpecificFallback(targetGoal: String): String = when (targetGoal.uppercase()) {
+            "ARABIC" -> "Your Arabic cards won't review themselves. Time to do the work."
+            "WALK" -> "Time for a walk. Your physical goal is waiting."
+            "GREEK" -> "The moussaka is waiting. Do your cards."
+            else -> "Your goal is waiting. Time to make progress."
+        }
+    }
+
     private var generativeModel: GenerativeModel? = null
 
     private fun setupLlm(): Boolean {
@@ -69,7 +78,7 @@ class SovereignBrain(private val context: Context) {
 
         try {
             val response = model.generateContent(prompt)
-            val nagText = response.text ?: "The moussaka is waiting. Do your cards."
+            val nagText = response.text ?: goalSpecificFallback(targetGoal)
             NarrativeResult(nagText.trim(), prompt)
         } catch (e: Exception) {
             Log.e("SovereignBrain", "LLM Inference failed: ${e.message}")

--- a/mecris-go-project/app/src/main/java/com/mecris/go/profile/ProfilePreferencesManager.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/profile/ProfilePreferencesManager.kt
@@ -21,30 +21,27 @@ class ProfilePreferencesManager(private val context: Context) {
 
     fun setPreferredHealthSource(value: String) {
         val trimmed = value.trim()
-        prefs.edit().apply {
-            if (trimmed.isBlank()) remove(KEY_PREFERRED_HEALTH_SOURCE) else putString(KEY_PREFERRED_HEALTH_SOURCE, trimmed)
-            commit()
-        }
+        val editor = prefs.edit()
+        if (trimmed.isBlank()) editor.remove(KEY_PREFERRED_HEALTH_SOURCE) else editor.putString(KEY_PREFERRED_HEALTH_SOURCE, trimmed)
+        editor.apply()
     }
 
     fun getPhoneNumber(): String? = prefs.getString(KEY_PHONE_NUMBER, null)
 
     fun setPhoneNumber(value: String) {
         val trimmed = value.trim()
-        prefs.edit().apply {
-            if (trimmed.isBlank()) remove(KEY_PHONE_NUMBER) else putString(KEY_PHONE_NUMBER, trimmed)
-            commit()
-        }
+        val editor = prefs.edit()
+        if (trimmed.isBlank()) editor.remove(KEY_PHONE_NUMBER) else editor.putString(KEY_PHONE_NUMBER, trimmed)
+        editor.apply()
     }
 
     fun getBeeminderUser(): String? = prefs.getString(KEY_BEEMINDER_USER, null)
 
     fun setBeeminderUser(value: String) {
         val trimmed = value.trim()
-        prefs.edit().apply {
-            if (trimmed.isBlank()) remove(KEY_BEEMINDER_USER) else putString(KEY_BEEMINDER_USER, trimmed)
-            commit()
-        }
+        val editor = prefs.edit()
+        if (trimmed.isBlank()) editor.remove(KEY_BEEMINDER_USER) else editor.putString(KEY_BEEMINDER_USER, trimmed)
+        editor.apply()
     }
 
     fun getLatitude(): String? = prefs.getString(KEY_LATITUDE, null)

--- a/mecris-go-project/app/src/test/java/com/mecris/go/ai/SovereignBrainFallbackTest.kt
+++ b/mecris-go-project/app/src/test/java/com/mecris/go/ai/SovereignBrainFallbackTest.kt
@@ -1,0 +1,44 @@
+package com.mecris.go.ai
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SovereignBrainFallbackTest {
+
+    @Test
+    fun `arabic fallback does not contain moussaka`() {
+        val fallback = SovereignBrain.goalSpecificFallback("ARABIC")
+        assertFalse(
+            "Arabic fallback should not mention moussaka, got: $fallback",
+            fallback.contains("moussaka", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `greek fallback contains moussaka`() {
+        val fallback = SovereignBrain.goalSpecificFallback("GREEK")
+        assertTrue(
+            "Greek fallback should mention moussaka, got: $fallback",
+            fallback.contains("moussaka", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `walk fallback does not contain moussaka`() {
+        val fallback = SovereignBrain.goalSpecificFallback("WALK")
+        assertFalse(
+            "Walk fallback should not mention moussaka, got: $fallback",
+            fallback.contains("moussaka", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `unknown goal returns generic fallback without moussaka`() {
+        val fallback = SovereignBrain.goalSpecificFallback("UNKNOWN_GOAL")
+        assertFalse(
+            "Generic fallback should not mention moussaka, got: $fallback",
+            fallback.contains("moussaka", ignoreCase = true)
+        )
+    }
+}

--- a/session_log.md
+++ b/session_log.md
@@ -1531,3 +1531,13 @@ This document summarizes the collaborative debugging session to establish a func
 - All code pushed to `origin/main` and `yebyen/main`.
 
 **Next**: Monitor the fuzzy notification triggers in the wild. Consider expanding the Sovereign Lab with more diagnostic tools or specialized narrative "moods."
+
+## 2026-04-17 🏛️ (2nd run) — Fix SovereignBrain LLM fallback text (moussaka-in-morning root cause)
+
+**Planned**: yebyen/mecris#205 — Fix `SovereignBrain.generateWithContext()` fallback text to be goal-specific, so Arabic nags get an Arabic fallback and Greek nags get the moussaka fallback.
+
+**Done**: Oriented — yebyen/mecris in sync with kingdonb/mecris (0/0), #204 (log out) and kingdonb/mecris#168 (Phase 4) both closed. Root cause of "moussaka in the morning" identified: `SovereignBrain.kt:72` used Greek-themed fallback text for ALL goals when Gemini Nano inference fails. TDG cycle: (1) red: `SovereignBrainFallbackTest` (4 cases — Arabic/Walk/unknown must not contain moussaka, Greek must contain it, commit `ee2126e`); (2) green: `companion object { fun goalSpecificFallback(targetGoal) }` with `when` expression per goal, line 81 updated to call it (commit `59c1bc5`). Secondary bug noted: `DelayedNagWorker.kt:135` message always says "cards come first" even when Arabic is cleared — harmless, logged for future session.
+
+**Skipped**: PR to kingdonb/mecris — blocked by push constraint (workflow pushes at session end). CI validation via pr-test deferred to next session.
+
+**Next**: After workflow pushes: open PR to kingdonb/mecris for SovereignBrain fix + log out button, then dispatch pr-test. Validate `SovereignBrainFallbackTest` (4 cases) passes in CI.

--- a/session_log.md
+++ b/session_log.md
@@ -1541,3 +1541,13 @@ This document summarizes the collaborative debugging session to establish a func
 **Skipped**: PR to kingdonb/mecris — blocked by push constraint (workflow pushes at session end). CI validation via pr-test deferred to next session.
 
 **Next**: After workflow pushes: open PR to kingdonb/mecris for SovereignBrain fix + log out button, then dispatch pr-test. Validate `SovereignBrainFallbackTest` (4 cases) passes in CI.
+
+## 2026-04-17 — Open PR #189, run pr-test, fix ProfilePreferencesManager apply() regression
+
+**Planned**: Open PR yebyen:main → kingdonb:main for SovereignBrain fallback fix + log out button; dispatch pr-test and validate all tests pass (yebyen/mecris#206).
+
+**Done**: PR kingdonb/mecris#189 opened. pr-test run #24564190870 completed — Python ✅ (461 passed, 5 skipped), Rust ✅ (102 passed), Android ❌ (5 failed). Root cause found: `5946d4e` changed `Editor.apply()` → `Editor.commit()` in ProfilePreferencesManager.kt breaking 4 pre-existing tests. Fixed in commit `57acd70` (green: restore apply(), explicit editor variable avoids Kotlin naming collision). Fix is local; workflow will push at session end.
+
+**Skipped**: pr-test re-validation of the Android fix — fix not pushed until session end, so re-run deferred to next session.
+
+**Next**: Dispatch pr-test against kingdonb/mecris#189 after workflow pushes 57acd70. Expected: Python 461, Rust 102, Android 24/0 failed (including SovereignBrainFallbackTest 4 cases).


### PR DESCRIPTION
## Summary

- **SovereignBrain**: Replace hard-coded Greek moussaka fallback with `goalSpecificFallback(targetGoal)` — Arabic nags no longer say \"The moussaka is waiting\" when on-device LLM inference fails
- **4 unit tests added**: `SovereignBrainFallbackTest` covers Arabic, Walk, GREEK, and unknown goal fallback cases
- **Log out button**: `PocketIdAuth.signOut()` clears auth state without clearing profile prefs (persist across re-login by design)

## Root Cause

`SovereignBrain.kt:72` used a hard-coded Greek moussaka fallback for ALL goals. When Gemini Nano inference returned null for an Arabic nag at 8am, the fallback text was culturally wrong.

## Commits

- `ee2126e` red: SovereignBrainFallbackTest — assert goal-specific fallback text
- `59c1bc5` green: add SovereignBrain.goalSpecificFallback() to fix moussaka-in-morning
- `37c59a0` archive(2026-04-17): fix SovereignBrain LLM fallback text

## Test Plan

- [ ] Python: 461 passed (5 skipped)
- [ ] Rust: 99 passed
- [ ] Android: BUILD SUCCESSFUL, `SovereignBrainFallbackTest` 4 cases pass

Tracked in yebyen/mecris#206

🤖 Generated with [Claude Code](https://claude.ai/claude-code)