### PR TITLE
Release 0.0.1-rc.1

### DIFF
--- a/.claude/skills/beeminder-audit/SKILL.md
+++ b/.claude/skills/beeminder-audit/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: Beeminder Audit
+description: Procedural guidance on safely auditing, modifying, and cleaning up Beeminder goal data (including odometer resets, @TARE mechanics, and timezone protections) without risking accidental derailment. Triggers on keywords like beeminder audit, beeminder cleanup, delete datapoints, tare.
+---
+# Beeminder Audit Skill
+
+Auditing, correcting, and backdating goal data on Beeminder carries a significant risk of accidental goal derailment. This skill provides a set of strict rules and procedures to safely audit and modify Beeminder goal data.
+
+## Risk Profile & Safety Rules
+1.  **Do Less / Ceiling Goals (Hard Cap)**:
+    *   For goals like API spend limits, adding a high value in the past can trigger historical ceiling violations, immediately derailing the goal.
+    *   **Always** inspect the current road parameters and historical cap levels before adding high historical values.
+2.  **Do More / Floor Goals**:
+    *   Deleting or moving a datapoint's date forward can create a temporary gap on that day, violating the minimum floor and triggering an immediate derailment.
+    *   **Never** shift a datapoint's date forward if it was the only data point satisfying the goal on its original date.
+3.  **Authentication & User-Awareness**:
+    *   Always verify you are querying and writing to the correct user's Beeminder goals.
+    *   Do not overwrite or delete values unilaterally without showing the current history and requesting explicit confirmation.
+
+## The `@TARE` Reset Mechanic
+For cumulative/odometer goals that reset every month (like `groqspend` or `claudespend`):
+1.  **Start-of-Month Tare**:
+    *   A tare datapoint of value `0.0` with the exact comment `@TARE` must be submitted on the 1st day of the month (or prior to the month's first real reading).
+    *   Beeminder uses this tare to offset the visual graph, resetting the cumulative cost back to zero for the new period.
+2.  **Audit Check**:
+    *   Verify that each month boundary has a `0.0` value with `@TARE` comment. If missing, a reset will not be registered visually, causing the graph to display cumulative lifetime costs rather than monthly costs.
+
+## Timezone Protection (The Daystamp Bug)
+Beeminder API accepts a `daystamp` string in `YYYYMMDD` format.
+1.  **Never rely on naive datetime conversions**:
+    *   Converting a naive UTC datetime (like `2026-06-01 00:00:00`) to local US/Eastern timezone shifts the timestamp back by 4-5 hours (to `2026-05-31 20:00:00-04:00`), changing the daystamp and corrupting the month boundary.
+2.  **Ensure explicit timezone metadata**:
+    *   Always construct timezone-aware UTC datetimes at 12:00 noon UTC (e.g. `datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)`) for historical entries. When converted to Eastern, the daystamp will remain on the correct day (e.g., `20260630`).
+
+## Audit Workflow
+1.  **Fetch History**: Retrieve the last 30-40 datapoints for the goal using the `get_goal_datapoints` API tool.
+2.  **Map Boundaries**: Organize readings by month and check for:
+    *   Presence of `@TARE` on Day 1 of each month.
+    *   Consistency of final odometer readings on the last day of each month.
+    *   Timezone shifting or duplicate datapoints.
+3.  **Confirm Edits with User**: Show a table of proposed changes (Deletions, Modifications, Additions) and request explicit approval.
+4.  **Execute & Verify**: Perform deletions/insertions in sequence, then re-fetch the history to display the finalized audit report.

--- a/.github/skills/beeminder-audit/SKILL.md
+++ b/.github/skills/beeminder-audit/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: Beeminder Audit
+description: Procedural guidance on safely auditing, modifying, and cleaning up Beeminder goal data (including odometer resets, @TARE mechanics, and timezone protections) without risking accidental derailment. Triggers on keywords like beeminder audit, beeminder cleanup, delete datapoints, tare.
+---
+# Beeminder Audit Skill
+
+Auditing, correcting, and backdating goal data on Beeminder carries a significant risk of accidental goal derailment. This skill provides a set of strict rules and procedures to safely audit and modify Beeminder goal data.
+
+## Risk Profile & Safety Rules
+1.  **Do Less / Ceiling Goals (Hard Cap)**:
+    *   For goals like API spend limits, adding a high value in the past can trigger historical ceiling violations, immediately derailing the goal.
+    *   **Always** inspect the current road parameters and historical cap levels before adding high historical values.
+2.  **Do More / Floor Goals**:
+    *   Deleting or moving a datapoint's date forward can create a temporary gap on that day, violating the minimum floor and triggering an immediate derailment.
+    *   **Never** shift a datapoint's date forward if it was the only data point satisfying the goal on its original date.
+3.  **Authentication & User-Awareness**:
+    *   Always verify you are querying and writing to the correct user's Beeminder goals.
+    *   Do not overwrite or delete values unilaterally without showing the current history and requesting explicit confirmation.
+
+## The `@TARE` Reset Mechanic
+For cumulative/odometer goals that reset every month (like `groqspend` or `claudespend`):
+1.  **Start-of-Month Tare**:
+    *   A tare datapoint of value `0.0` with the exact comment `@TARE` must be submitted on the 1st day of the month (or prior to the month's first real reading).
+    *   Beeminder uses this tare to offset the visual graph, resetting the cumulative cost back to zero for the new period.
+2.  **Audit Check**:
+    *   Verify that each month boundary has a `0.0` value with `@TARE` comment. If missing, a reset will not be registered visually, causing the graph to display cumulative lifetime costs rather than monthly costs.
+
+## Timezone Protection (The Daystamp Bug)
+Beeminder API accepts a `daystamp` string in `YYYYMMDD` format.
+1.  **Never rely on naive datetime conversions**:
+    *   Converting a naive UTC datetime (like `2026-06-01 00:00:00`) to local US/Eastern timezone shifts the timestamp back by 4-5 hours (to `2026-05-31 20:00:00-04:00`), changing the daystamp and corrupting the month boundary.
+2.  **Ensure explicit timezone metadata**:
+    *   Always construct timezone-aware UTC datetimes at 12:00 noon UTC (e.g. `datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)`) for historical entries. When converted to Eastern, the daystamp will remain on the correct day (e.g., `20260630`).
+
+## Audit Workflow
+1.  **Fetch History**: Retrieve the last 30-40 datapoints for the goal using the `get_goal_datapoints` API tool.
+2.  **Map Boundaries**: Organize readings by month and check for:
+    *   Presence of `@TARE` on Day 1 of each month.
+    *   Consistency of final odometer readings on the last day of each month.
+    *   Timezone shifting or duplicate datapoints.
+3.  **Confirm Edits with User**: Show a table of proposed changes (Deletions, Modifications, Additions) and request explicit approval.
+4.  **Execute & Verify**: Perform deletions/insertions in sequence, then re-fetch the history to display the finalized audit report.

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ run-local: build-wasm
 		--variable oidc_jwks_json='$(JWKS_JSON)' \
 		--variable cloud_provider=local \
 		--variable auth_bypass=true \
+		--truncate-logs \
 		--listen 0.0.0.0:3000
 
 deploy-all: deploy-fermyon deploy-akamai

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Mission**: Transform Mecris from reactive MCP server to autonomous cognitive agent with rich contextual awareness
 
 ## 📊 Current Status
-- **Version**: v0.0.1-beta.10 (2026-06-11) ✅
+- **Version**: v0.0.1-rc.1 (2026-06-30) ✅
 - **Budget**: $20.88 remaining (Expires 2026-04-14)
 - **Foundation**: Production-ready MCP server with Beeminder, Budget, and Twilio integrations ✅
 - **Progress**: Autonomous nagging implemented via MCP Scheduler and Android Heartbeat ✅

--- a/VERSION_MANIFEST.json
+++ b/VERSION_MANIFEST.json
@@ -1,11 +1,11 @@
 {
   "suite_name": "Mecris Personal Accountability Suite",
-  "release_date": "2026-06-11",
-  "total_version": "0.0.1-beta.10",
+  "release_date": "2026-06-30",
+  "total_version": "0.0.1-rc.1",
   "components": {
     "android_app": {
       "name": "Mecris-Go Android",
-      "version": "0.0.1-beta.10",
+      "version": "0.0.1-rc.1",
       "features": [
         "OIDC Submarine Mode Fixes",
         "WorkManager Heartbeat",
@@ -17,7 +17,7 @@
     },
     "spin_backend": {
       "name": "Mecris-Go Sync Service (Spin)",
-      "version": "0.0.1-beta.10",
+      "version": "0.0.1-rc.1",
       "features": [
         "Arabic Skip Counter",
         "Multi-Component Layout",
@@ -29,7 +29,7 @@
     },
     "python_mcp": {
       "name": "Mecris MCP Server",
-      "version": "0.0.1-beta.10",
+      "version": "0.0.1-rc.1",
       "features": [
         "Hardened Authentication",
         "Enriched System Pulse",
@@ -40,7 +40,7 @@
     },
     "neon_infrastructure": {
       "name": "Neon PostgreSQL Cloud",
-      "version": "0.0.1-beta.10",
+      "version": "0.0.1-rc.1",
       "features": [
         "Ghost Presence Table",
         "Message Log with Compliance Status",

--- a/beeminder_client.py
+++ b/beeminder_client.py
@@ -159,6 +159,8 @@ class BeeminderClient:
                 response = await self.client.get(url, params=params)
             elif method == "POST":
                 response = await self.client.post(url, params=params, json=data or {})
+            elif method == "DELETE":
+                response = await self.client.delete(url, params=params)
             else:
                 raise BeeminderAPIError(f"Unsupported HTTP method: {method}", status_code=400)
             
@@ -300,6 +302,21 @@ class BeeminderClient:
         )
         
         return result is not None
+
+    async def delete_datapoint(self, goal_slug: str, datapoint_id: str) -> bool:
+        """Delete a datapoint from a goal
+        
+        Args:
+            goal_slug: The goal to delete the datapoint from
+            datapoint_id: The ID of the datapoint to delete
+        """
+        endpoint = f"users/{self.username}/goals/{goal_slug}/datapoints/{datapoint_id}.json"
+        try:
+            await self._api_call(endpoint, method="DELETE")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to delete datapoint {datapoint_id} for goal {goal_slug}: {e}")
+            return False
     
     def _classify_derail_risk(self, safebuf: int) -> str:
         """Classify derailment risk based on safebuf days"""

--- a/boris-fiona-walker/spin.toml
+++ b/boris-fiona-walker/spin.toml
@@ -2,7 +2,7 @@ spin_manifest_version = 2
 
 [application]
 name = "boris-fiona-walker"
-version = "0.0.1-beta.10"
+version = "0.0.1-rc.1"
 authors = ["Kingdon Barrett <kingdon@urmanac.com>"]
 description = "WASM walk reminder system for Boris and Fiona"
 

--- a/groq_odometer_tracker.py
+++ b/groq_odometer_tracker.py
@@ -109,7 +109,9 @@ class GroqOdometerTracker:
         if not self.neon_url:
             return {"recorded": False, "reason": "No DB configured"}
             
-        now = datetime.now()
+        from datetime import timezone
+        import calendar
+        now = datetime.now(timezone.utc)
         target_month = month if month else now.strftime("%Y-%m")
         
         # Check for odometer reset (only for current month recordings)
@@ -128,9 +130,11 @@ class GroqOdometerTracker:
                 self._finalize_month(last_month, last_value, target_user_id)
         
         try:
-            # For historical records, use a timestamp from that month
+            # For historical records, use the last day of the specified month at 12:00 noon UTC
             if month:
-                historical_date = datetime.strptime(f"{month}-01", "%Y-%m-%d")
+                year, m = map(int, month.split("-"))
+                _, last_day = calendar.monthrange(year, m)
+                historical_date = datetime(year, m, last_day, 12, 0, tzinfo=timezone.utc)
                 record_timestamp = historical_date
             else:
                 record_timestamp = now

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -212,6 +212,8 @@ async def upload_walk(walk_data: Dict[str, Any], user_id: str = Depends(get_auth
 async def get_languages(user_id: str = Depends(get_authorized_user)):
     # Use the unified velocity calculator to get enriched stats (absolute_target, target_flow_rate, goal_met)
     stats_dict = await get_language_velocity_stats(user_id)
+    if "error" in stats_dict:
+        raise HTTPException(status_code=503, detail=stats_dict["error"])
     
     lang_list = []
     for name, data in stats_dict.items():
@@ -266,24 +268,19 @@ async def post_heartbeat(data: Dict[str, Any], user_id: str = Depends(get_author
     await asyncio.to_thread(scheduler._update_heartbeat, role, process_id, user_id)
     return {"status": "success", "mcp_server_active": True}
 
-@app.post("/internal/cloud-sync", status_code=202)
+@app.post("/internal/cloud-sync")
 async def trigger_cloud_sync_endpoint(user_id: str = Depends(get_authorized_user)):
     logger.info(f"Android app triggered cloud sync for {user_id}")
-    
-    # Run the slow sync in a background task
-    async def run_sync():
-        try:
-            await language_sync_service.sync_all(user_id=user_id)
-            logger.info(f"Background cloud sync complete for {user_id}")
-        except Exception as e:
-            logger.error(f"Background cloud sync failed for {user_id}: {e}")
-
-    asyncio.create_task(run_sync())
-    
-    return {
-        "status": "accepted", 
-        "message": "Cloud sync started in background. Please check /languages in a few moments for updates."
-    }
+    try:
+        await language_sync_service.sync_all(user_id=user_id)
+        logger.info(f"Cloud sync complete for {user_id}")
+        return {
+            "status": "success", 
+            "message": "Cloud sync complete"
+        }
+    except Exception as e:
+        logger.error(f"Cloud sync failed for {user_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/intelligent-reminder/trigger")
 async def trigger_reminder_endpoint(user_id: str = Depends(get_authorized_user)):
@@ -1668,10 +1665,11 @@ async def get_daily_aggregate_status(user_id: str = None) -> Dict[str, Any]:
             stat = next((v for k, v in lang_stats.items() if isinstance(v, dict) and k.lower() == lang_key), None)
             if stat:
                 # Add to aggregate goals
+                target_flow = stat.get("target_flow_rate")
                 goals.append({
                     "name": f"{lang_key}_review",
                     "label": label,
-                    "satisfied": bool(stat.get("goal_met", False)),
+                    "satisfied": bool(stat.get("goal_met", False)) or (target_flow is not None and target_flow <= 0.0),
                     "status": stat.get("status", "unknown"),
                 })
             else:

--- a/mecris-go-project/app/build.gradle.kts
+++ b/mecris-go-project/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.mecris.go"
         minSdk = 31
         targetSdk = 35
-        versionCode = 25
-        versionName = "0.0.1-beta.10"
+        versionCode = 26
+        versionName = "0.0.1-rc.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/mecris-go-spin/sync-service/Cargo.lock
+++ b/mecris-go-spin/sync-service/Cargo.lock
@@ -95,17 +95,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,15 +606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,7 +729,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -765,7 +745,7 @@ dependencies = [
  "r-efi",
  "rand_core 0.10.1",
  "wasip2",
- "wasip3",
+ "wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06",
  "wasm-bindgen",
 ]
 
@@ -819,6 +799,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1278,12 +1261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
 name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,16 +1505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "routefinder"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0971d3c8943a6267d6bd0d782fdc4afa7593e7381a92a3df950ff58897e066b5"
-dependencies = [
- "smartcow",
- "smartstring",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,26 +1698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "smartcow"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656fcb1c1fca8c4655372134ce87d8afdf5ec5949ebabe8d314be0141d8b5da2"
-dependencies = [
- "smartstring",
-]
-
-[[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "static_assertions",
- "version_check",
-]
-
-[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,24 +1723,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin-executor"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba409d00af758cd5de128da4a801e891af0545138f66a688f025f6d4e33870b"
-dependencies = [
- "futures",
- "once_cell",
- "wasi 0.13.1+wasi-0.2.0",
-]
-
-[[package]]
 name = "spin-macro"
-version = "5.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f959f16928e3c023468e41da9ebb77442e2ce22315e8dab11508fe76b3567ee1"
+checksum = "11e483b94d5bcfac493caf0427fa875063e3e8604d0466a4ab491ec200a42857"
 dependencies = [
- "anyhow",
- "bytes",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1801,29 +1735,25 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "5.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8951c7c4ab7f87f332d497789eeed9631c8116988b628b4851eb2fa999ead019"
+checksum = "4fd2abac3eb2ee249c2241ab87f7b1287f36172c8cc1ea815c19c85e41ede44d"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "chrono",
- "form_urlencoded",
  "futures",
  "http",
- "once_cell",
+ "http-body",
+ "http-body-util",
  "postgres_range",
- "routefinder",
  "rust_decimal",
  "serde",
  "serde_json",
- "spin-executor",
  "spin-macro",
  "thiserror",
  "uuid",
- "wasi 0.13.1+wasi-0.2.0",
- "wit-bindgen 0.51.0",
+ "wasip3 0.6.0+wasi-0.3.0-rc-2026-03-15",
 ]
 
 [[package]]
@@ -1845,12 +1775,6 @@ dependencies = [
  "base64ct",
  "der 0.8.0",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -2054,15 +1978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.13.1+wasi-0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f43d1c36145feb89a3e61aa0ba3e582d976a8ab77f1474aa0adb80800fe0cf8"
-dependencies = [
- "wit-bindgen-rt",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,12 +1996,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.6.0+wasi-0.3.0-rc-2026-03-15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed83456dd6a0b8581998c0365e4651fa2997e5093b49243b7f35391afaa7a3d9"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "thiserror",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
 name = "wasix"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332"
 dependencies = [
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -2155,6 +2083,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2117,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665fe59e56cc9b419ca6fcca56673e3421d1a5011e3b65caf6b726fd9e041d10"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.247.0",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2148,18 @@ checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags",
  "hashbrown 0.16.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
 ]
@@ -2289,7 +2251,6 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "bitflags",
  "wit-bindgen-rust-macro 0.51.0",
 ]
 
@@ -2308,6 +2269,11 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+dependencies = [
+ "bitflags",
+ "futures",
+ "wit-bindgen-rust-macro 0.57.1",
+]
 
 [[package]]
 name = "wit-bindgen-core"
@@ -2332,12 +2298,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.24.0"
+name = "wit-bindgen-core"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0780cf7046630ed70f689a098cd8d56c5c3b22f2a7379bbdb088879963ff96"
+checksum = "02dee27a2dc20d1008016c742ec9fc6ea498492994ba3750be7454cbc97ff04c"
 dependencies = [
- "bitflags",
+ "anyhow",
+ "heck",
+ "wit-parser 0.247.0",
 ]
 
 [[package]]
@@ -2373,6 +2341,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rust"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5007dae772945b7a5003d69d90a3a4a78929d41f19d004e980c4259a6af4484"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata 0.247.0",
+ "wit-bindgen-core 0.57.1",
+ "wit-component 0.247.0",
+]
+
+[[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2384,21 @@ dependencies = [
  "syn 2.0.117",
  "wit-bindgen-core 0.54.0",
  "wit-bindgen-rust 0.54.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9237d678e3513ad24e96fe98beacdc0db6405284ba2a2400418cf0d42caa89"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core 0.57.1",
+ "wit-bindgen-rust 0.57.1",
 ]
 
 [[package]]
@@ -2441,6 +2440,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-component"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d567162a6b9843080e5e0053f696623ff694bae8ae017c9ec536d1873bbe3d8"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.247.0",
+ "wasm-metadata 0.247.0",
+ "wasmparser 0.247.0",
+ "wit-parser 0.247.0",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2493,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffe4064318cdf3c08cb99343b44c039fcefe61ccdf58aa9975285f13d74d1fc"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]

--- a/mecris-go-spin/sync-service/Cargo.toml
+++ b/mecris-go-spin/sync-service/Cargo.toml
@@ -26,7 +26,7 @@ jwt-simple = "0.12.11"
 aes-gcm = "0.10.3"
 hex = "0.4.3"
 getrandom = "0.2.12"
-spin-sdk = "5.0.0"
+spin-sdk = "6.0.0"
 spin-cron-sdk = { git = "https://github.com/fermyon/spin-trigger-cron" }
 urlencoding = "2.1.3"
 futures = "0.3.32"

--- a/mecris-go-spin/sync-service/spin.toml
+++ b/mecris-go-spin/sync-service/spin.toml
@@ -4,7 +4,7 @@ spin_manifest_version = 2
 
 [application]
 name = "mecris-sync-v2"
-version = "0.0.1-beta.10"
+version = "0.0.1-rc.1"
 authors = ["Kingdon B <kingdon@urmanac.com>"]
 description = ""
 

--- a/mecris-go-spin/sync-service/src/lib.rs
+++ b/mecris-go-spin/sync-service/src/lib.rs
@@ -1,11 +1,12 @@
+use spin_cron_sdk::cron_component;
 use serde::{Deserialize, Serialize};
 use spin_sdk::{
     http::{Request, Response, Method},
-    http_component,
+    http_service,
     pg::{Connection, ParameterValue, DbValue},
     variables,
 };
-use spin_cron_sdk::{cron_component, Metadata};
+use http_body_util::BodyExt;
 use sha2::{Sha256, Digest};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use jwt_simple::prelude::*;
@@ -35,40 +36,21 @@ fn db_to_f64(v: &DbValue) -> f64 {
 fn db_to_str(v: &DbValue) -> String { match v { DbValue::Str(s) => s.clone(), _ => String::new() } }
 fn db_to_bool(v: &DbValue) -> bool { match v { DbValue::Boolean(b) => *b, _ => false } }
 
-fn json_response<T: Serialize>(status: u16, data: &T) -> anyhow::Result<Response> {
-    let body = serde_json::to_vec(data)?;
-    
-    Ok(Response::builder()
-        .status(status)
-        .header("content-type", "application/json")
-        .header("access-control-allow-origin", "*")
-        .body(body)
-        .build())
-}
-
-fn text_response(status: u16, text: &str) -> anyhow::Result<Response> {
-    Ok(Response::builder()
-        .status(status)
-        .header("access-control-allow-origin", "*")
-        .body(text.as_bytes().to_vec())
-        .build())
-}
+fn json_response<T: Serialize>(s: u16, d: &T) -> anyhow::Result<Response<String>> { Ok(Response::builder().status(s).header("content-type", "application/json").header("access-control-allow-origin", "*").body(serde_json::to_string(d)?)?) }
+fn text_response(s: u16, t: &str) -> anyhow::Result<Response<String>> { Ok(Response::builder().status(s).header("access-control-allow-origin", "*").body(t.to_string())?) }
+fn add_cors(mut r: Response<String>) -> Response<String> { r.headers_mut().insert("access-control-allow-origin", spin_sdk::http::HeaderValue::from_static("*")); r }
 
 #[cron_component]
-async fn handle_cron(_metadata: Metadata) -> anyhow::Result<()> {
-    let db_url = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) {
-        Ok(url) if !url.is_empty() => url,
-        _ => return Ok(()),
-    };
-    let default_user_id = "c0a81a4b-115a-4eb6-bc2c-40908c58bf64";
-    let _ = run_clozemaster_scraper(&db_url, default_user_id).await;
+async fn handle_cron(_m: spin_cron_sdk::Metadata) -> anyhow::Result<()> {
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let _ = run_clozemaster_scraper(&db, "c0a81a4b-115a-4eb6-bc2c-40908c58bf64").await;
     Ok(())
 }
 
-#[http_component]
-async fn handle_sync_service(req: Request) -> anyhow::Result<Response> {
-    let mut path = req.path().to_string();
-    let method = req.method().clone();
+#[http_service]
+async fn handle_sync_service(req: Request) -> anyhow::Result<Response<String>> {
+    let mut path = req.uri().path().to_string();
+    let method = req.method();
     
     // Fix for full URLs in path
     if path.starts_with("http") {
@@ -76,68 +58,51 @@ async fn handle_sync_service(req: Request) -> anyhow::Result<Response> {
             path = format!("/{}", p);
         }
     }
-    
 
-    if method == Method::Options {
-        return Ok(Response::builder()
-            .status(204)
-            .header("access-control-allow-origin", "*")
-            .header("access-control-allow-methods", "GET, POST, PATCH, OPTIONS")
-            .header("access-control-allow-headers", "authorization, content-type, x-internal-api-key")
-            .build());
-    }
-
+    if method == &Method::OPTIONS { return Ok(Response::builder().status(204).header("access-control-allow-origin", "*").header("access-control-allow-methods", "GET, POST, PATCH, OPTIONS").header("access-control-allow-headers", "authorization, content-type, x-internal-api-key").body(String::new())?); }
     let resp = match (path.as_str(), method) {
-        ("/walks", Method::Post) => handle_walks_post(req).await,
-        ("/budget", Method::Get) => handle_budget_get(req).await,
-        ("/languages", Method::Get) => handle_languages_get(req).await,
-        ("/languages/multiplier", Method::Post) => handle_multiplier_post(req).await,
-        ("/health", Method::Get) => handle_health_get(req).await,
-        ("/heartbeat", Method::Post) => handle_heartbeat_post(req).await,
-        ("/internal/cloud-sync", Method::Post) => handle_cloud_sync(req).await,
-        ("/aggregate-status", Method::Get) => handle_aggregate_status_get(req).await,
-        ("/profile", Method::Post) => handle_profile_post(req).await,
-        ("/profile", Method::Get) => handle_profile_get(req).await,
+        ("/walks", &Method::POST) => handle_walks_post(req).await?,
+        ("/budget", &Method::GET) => handle_budget_get(req).await?,
+        ("/languages", &Method::GET) => handle_languages_get(req).await?,
+        ("/languages/multiplier", &Method::POST) => handle_multiplier_post(req).await?,
+        ("/health", &Method::GET) => handle_health_get(req).await?,
+        ("/heartbeat", &Method::POST) => handle_heartbeat_post(req).await?,
+        ("/internal/cloud-sync", &Method::POST) => handle_cloud_sync(req).await?,
+        ("/aggregate-status", &Method::GET) => handle_aggregate_status_get(req).await?,
+        ("/profile", &Method::POST) => handle_profile_post(req).await?,
+        ("/profile", &Method::GET) => handle_profile_get(req).await?,
         ("/internal/trigger-reminders", _) => {
-            let cfg = variables::get("internal_api_key").unwrap_or_default();
-            let key = req.header("x-internal-api-key").and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-            if !internal_api_key_ok(&cfg, key) { text_response(401, "Unauthorized") } else { handle_trigger_reminders_post(req).await }
+            let cfg = variables::get("internal_api_key").await.unwrap_or_default();
+            let key = req.headers().get("x-internal-api-key").and_then(|v| v.to_str().ok());
+            if !internal_api_key_ok(&cfg, key) { text_response(401, "Unauthorized")? } else { handle_trigger_reminders_post(req).await? }
         },
         ("/internal/failover-sync", _) => {
-            let cfg = variables::get("internal_api_key").unwrap_or_default();
-            let key = req.header("x-internal-api-key").and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-            if !internal_api_key_ok(&cfg, key) { text_response(401, "Unauthorized") } else { handle_failover_sync_post(req).await }
+            let cfg = variables::get("internal_api_key").await.unwrap_or_default();
+            let key = req.headers().get("x-internal-api-key").and_then(|v| v.to_str().ok());
+            if !internal_api_key_ok(&cfg, key) { text_response(401, "Unauthorized")? } else { handle_failover_sync_post(req).await? }
         },
-        ("/internal/weather-heuristic", Method::Get) => handle_weather_heuristic_get(req).await,
-        ("/internal/request-phone-verification", Method::Post) => handle_request_phone_verification_post(req).await,
-        ("/internal/confirm-phone-verification", Method::Post) => handle_confirm_phone_verification_post(req).await,
-        ("/internal/twilio-webhook", Method::Post) => handle_twilio_webhook_post(req).await,
-        _ => text_response(404, "Not Found"),
+        ("/internal/weather-heuristic", &Method::GET) => handle_weather_heuristic_get(req).await?,
+        ("/internal/request-phone-verification", &Method::POST) => handle_request_phone_verification_post(req).await?,
+        ("/internal/confirm-phone-verification", &Method::POST) => handle_confirm_phone_verification_post(req).await?,
+        ("/internal/twilio-webhook", &Method::POST) => handle_twilio_webhook_post(req).await?,
+        _ => text_response(404, "Not Found")?,
     };
-
-    match resp {
-        Ok(r) => Ok(r),
-        Err(e) => {
-            println!("Error processing request {}: {:?}", path, e);
-            text_response(500, &format!("Internal Server Error: {}", e))
-        }
-    }
+    Ok(add_cors(resp))
 }
 
-async fn handle_aggregate_status_get(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let full = req.uri().contains("full=true");
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-    let walk_rs = conn.query("SELECT COUNT(*) FROM walk_inferences WHERE (start_time::TIMESTAMPTZ AT TIME ZONE 'US/Eastern')::DATE = (CURRENT_TIMESTAMP AT TIME ZONE 'US/Eastern')::DATE AND CAST(step_count AS INTEGER) >= 2000 AND user_id = $1", &[ParameterValue::Str(uid.clone())])?;
-    let walked = !walk_rs.rows.is_empty() && (db_to_i32(&walk_rs.rows[0][0]) > 0);
-    let lang_rows = conn.query("SELECT language_name, current_reviews, tomorrow_reviews, pump_multiplier::FLOAT8, daily_completions FROM language_stats WHERE user_id = $1", &[ParameterValue::Str(uid.clone())])?;
-    let user_rows = conn.query("SELECT vacation_mode_until::TEXT, phone_verified FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())])?;
-    let (vaca, phone) = if !user_rows.rows.is_empty() { (match &user_rows.rows[0][0] { DbValue::Str(s) if !s.is_empty() => Some(s.clone()), _ => None }, db_to_bool(&user_rows.rows[0][1])) } else { (None, false) };
+async fn handle_aggregate_status_get(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let full = req.uri().query().map(|q| q.contains("full=true")).unwrap_or(false);
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let walk_rs = conn.query("SELECT COUNT(*) FROM walk_inferences WHERE (start_time::TIMESTAMPTZ AT TIME ZONE 'US/Eastern')::DATE = (CURRENT_TIMESTAMP AT TIME ZONE 'US/Eastern')::DATE AND CAST(step_count AS INTEGER) >= 2000 AND user_id = $1", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
+    let walked = !walk_rs.is_empty() && (db_to_i32(&walk_rs[0][0]) > 0);
+    let lang_rows = conn.query("SELECT language_name, current_reviews, tomorrow_reviews, pump_multiplier::FLOAT8, daily_completions FROM language_stats WHERE user_id = $1", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
+    let user_rows = conn.query("SELECT vacation_mode_until::TEXT, phone_verified FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
+    let (vaca, phone) = if !user_rows.is_empty() { (match &user_rows[0][0] { DbValue::Str(s) if !s.is_empty() => Some(s.clone()), _ => None }, db_to_bool(&user_rows[0][1])) } else { (None, false) };
     let mut total_goals = 1; let mut goals_met = if walked { 1 } else { 0 };
     let (mut arabic_met, mut greek_met) = (false, false);
-    for r in &lang_rows.rows {
+    for r in &lang_rows {
         let n = db_to_str(&r[0]);
         let (cur, tom, mult, done) = (db_to_i32(&r[1]), db_to_i32(&r[2]), db_to_f64(&r[3]), db_to_i32(&r[4]));
         let (_, _, met) = calculate_targets(cur, tom, mult, done);
@@ -149,12 +114,12 @@ async fn handle_aggregate_status_get(req: Request) -> anyhow::Result<Response> {
     #[derive(Serialize)] struct AggResp { score: String, goals_met: i32, total_goals: i32, all_clear: bool, components: Comp, vacation_mode_until: Option<String>, phone_verified: bool, modalities: Option<Vec<Mod>> }
     let mut mods = None;
     if full {
-        let p_rows = conn.query("SELECT role, heartbeat::TEXT, CAST(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - heartbeat)) / 60 AS BIGINT) AS mins FROM scheduler_election WHERE user_id = $1 OR user_id IS NULL ORDER BY heartbeat DESC", &[ParameterValue::Str(uid.clone())])?;
+        let p_rows = conn.query("SELECT role, heartbeat::TEXT, CAST(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - heartbeat)) / 60 AS BIGINT) AS mins FROM scheduler_election WHERE user_id = $1 OR user_id IS NULL ORDER BY heartbeat DESC", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
         let mut ms = Vec::new();
-        for r in &p_rows.rows {
+        for r in &p_rows {
             let role = db_to_str(&r[0]);
             let display = match role.as_str() { "leader" => "MCP SERVER", "android_client" => "ANDROID", "akamai_functions" => "AKAMAI", "fermyon_cloud" => "FERMYON", _ => &role };
-            let mins = match r[2] { DbValue::Int64(i) => i as u64, _ => 9999 };
+            let mins = match &r[2] { DbValue::Int64(i) => *i as u64, _ => 9999 };
             ms.push(Mod { role: display.to_string(), status: get_modality_status(&role, mins).to_string(), last_seen: db_to_str(&r[1]) });
         }
         mods = Some(ms);
@@ -168,95 +133,88 @@ fn calculate_targets(cur: i32, tom: i32, mult: f64, done: i32) -> (i32, f64, boo
     (target, rate, done >= target)
 }
 
-async fn handle_profile_post(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let body = req.body();
+async fn handle_profile_post(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let body = req.into_body().collect().await.map_err(|e| anyhow::anyhow!("Body: {:?}", e))?.to_bytes();
     #[derive(Deserialize)] struct ProfReq { phone_number: Option<String>, beeminder_user: Option<String>, latitude: Option<f64>, longitude: Option<f64>, vacation_mode: Option<bool>, autonomous_sync_enabled: Option<bool>, notification_prefs: Option<serde_json::Value> }
-    let pr: ProfReq = serde_json::from_slice(body)?;
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-    if let Some(p) = &pr.phone_number { let enc = encrypt_token(p).await?; conn.execute("UPDATE users SET phone_number_encrypted = $1, phone_verified = FALSE WHERE pocket_id_sub = $2", &[ParameterValue::Str(enc), ParameterValue::Str(uid.clone())])?; }
-    if let Some(bu) = &pr.beeminder_user { let enc = encrypt_token(bu).await?; conn.execute("UPDATE users SET beeminder_user_encrypted = $1 WHERE pocket_id_sub = $2", &[ParameterValue::Str(enc), ParameterValue::Str(uid.clone())])?; }
-    if let Some(lat) = pr.latitude { conn.execute("UPDATE users SET location_lat = $1 WHERE pocket_id_sub = $2", &[ParameterValue::Floating64(lat), ParameterValue::Str(uid.clone())])?; }
-    if let Some(lon) = pr.longitude { conn.execute("UPDATE users SET location_lon = $1 WHERE pocket_id_sub = $2", &[ParameterValue::Floating64(lon), ParameterValue::Str(uid.clone())])?; }
-    if let Some(vac) = pr.vacation_mode { if !vac { conn.execute("UPDATE users SET vacation_mode_until = NULL WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())])?; } else { let u = (chrono::Utc::now() + chrono::Duration::days(1)).to_rfc3339(); conn.execute("UPDATE users SET vacation_mode_until = $1::TIMESTAMPTZ WHERE pocket_id_sub = $2", &[ParameterValue::Str(u), ParameterValue::Str(uid.clone())])?; } }
-    if let Some(sync) = pr.autonomous_sync_enabled { conn.execute("UPDATE users SET autonomous_sync_enabled = $1 WHERE pocket_id_sub = $2", &[ParameterValue::Boolean(sync), ParameterValue::Str(uid.clone())])?; }
-    if let Some(pref) = &pr.notification_prefs { conn.execute("UPDATE users SET notification_prefs = $1::JSONB WHERE pocket_id_sub = $2", &[ParameterValue::Str(serde_json::to_string(pref)?), ParameterValue::Str(uid.clone())])?; }
+    let pr: ProfReq = serde_json::from_slice(&body)?;
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    if let Some(p) = &pr.phone_number { let enc = encrypt_token(p).await?; conn.execute("UPDATE users SET phone_number_encrypted = $1, phone_verified = FALSE WHERE pocket_id_sub = $2", &[ParameterValue::Str(enc), ParameterValue::Str(uid.clone())]).await?; }
+    if let Some(bu) = &pr.beeminder_user { let enc = encrypt_token(bu).await?; conn.execute("UPDATE users SET beeminder_user_encrypted = $1 WHERE pocket_id_sub = $2", &[ParameterValue::Str(enc), ParameterValue::Str(uid.clone())]).await?; }
+    if let Some(lat) = pr.latitude { conn.execute("UPDATE users SET location_lat = $1 WHERE pocket_id_sub = $2", &[ParameterValue::Floating64(lat), ParameterValue::Str(uid.clone())]).await?; }
+    if let Some(lon) = pr.longitude { conn.execute("UPDATE users SET location_lon = $1 WHERE pocket_id_sub = $2", &[ParameterValue::Floating64(lon), ParameterValue::Str(uid.clone())]).await?; }
+    if let Some(vac) = pr.vacation_mode { if !vac { conn.execute("UPDATE users SET vacation_mode_until = NULL WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())]).await?; } else { let u = (chrono::Utc::now() + chrono::Duration::days(1)).to_rfc3339(); conn.execute("UPDATE users SET vacation_mode_until = $1::TIMESTAMPTZ WHERE pocket_id_sub = $2", &[ParameterValue::Str(u), ParameterValue::Str(uid.clone())]).await?; } }
+    if let Some(sync) = pr.autonomous_sync_enabled { conn.execute("UPDATE users SET autonomous_sync_enabled = $1 WHERE pocket_id_sub = $2", &[ParameterValue::Boolean(sync), ParameterValue::Str(uid.clone())]).await?; }
+    if let Some(pref) = &pr.notification_prefs { conn.execute("UPDATE users SET notification_prefs = $1::JSONB WHERE pocket_id_sub = $2", &[ParameterValue::Str(serde_json::to_string(pref)?), ParameterValue::Str(uid.clone())]).await?; }
     json_response(200, &StatusResponse { status: "success".to_string(), message: "Profile updated".to_string() })
 }
 
-async fn handle_profile_get(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-     let rs = conn.query("SELECT phone_number_encrypted, beeminder_user_encrypted, location_lat, location_lon, vacation_mode_until::TEXT, autonomous_sync_enabled FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())])?;
-    if rs.rows.is_empty() { return Ok(text_response(404, "User not found")?); }
+async fn handle_profile_get(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let rs = conn.query("SELECT phone_number_encrypted, beeminder_user_encrypted, location_lat, location_lon, vacation_mode_until::TEXT, autonomous_sync_enabled FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
+    if rs.is_empty() { return Ok(text_response(404, "User not found")?); }
     #[derive(Serialize)] struct ProfResp { phone_number: Option<String>, beeminder_user: Option<String>, latitude: Option<f64>, longitude: Option<f64>, vacation_mode_until: Option<String>, autonomous_sync_enabled: bool }
-    let r = &rs.rows[0];
-    let p = match &r[0] { DbValue::Str(s) if !s.is_empty() => decrypt_token(&s).await.ok(), _ => None };
-    let bu = match &r[1] { DbValue::Str(s) if !s.is_empty() => decrypt_token(&s).await.ok(), _ => None };
-    json_response(200, &ProfResp { phone_number: p, beeminder_user: bu, latitude: match rs.rows[0][2] { DbValue::Floating64(f) => Some(f), _ => None }, longitude: match rs.rows[0][3] { DbValue::Floating64(f) => Some(f), _ => None }, vacation_mode_until: match &rs.rows[0][4] { DbValue::Str(s) if !s.is_empty() => Some(s.clone()), _ => None }, autonomous_sync_enabled: db_to_bool(&rs.rows[0][5]) })
+    let r = &rs[0];
+    let p = match &r[0] { DbValue::Str(s) if !s.is_empty() => decrypt_token(s).await.ok(), _ => None };
+    let bu = match &r[1] { DbValue::Str(s) if !s.is_empty() => decrypt_token(s).await.ok(), _ => None };
+    json_response(200, &ProfResp { phone_number: p, beeminder_user: bu, latitude: match &r[2] { DbValue::Floating64(f) => Some(*f), _ => None }, longitude: match &r[3] { DbValue::Floating64(f) => Some(*f), _ => None }, vacation_mode_until: match &r[4] { DbValue::Str(s) if !s.is_empty() => Some(s.clone()), _ => None }, autonomous_sync_enabled: match &r[5] { DbValue::Boolean(b) => *b, _ => false } })
 }
 
-async fn handle_cloud_sync(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
+async fn handle_cloud_sync(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
     let _ = run_clozemaster_scraper(&db, &uid).await;
     json_response(200, &StatusResponse { status: "success".to_string(), message: "Sync initiated".to_string() })
 }
 
-async fn handle_health_get(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-    register_cloud_heartbeat(&conn, &uid).await;
+async fn handle_health_get(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let _ = register_cloud_heartbeat(&conn, &uid).await;
     #[derive(Serialize)] struct HealthResp { status: String, home_server_active: bool, leader_pid: String, last_seen: String }
     let mut active = false; let mut pid = "none".to_string(); let mut last = "never".to_string();
-     let rs = conn.query("SELECT (heartbeat > CURRENT_TIMESTAMP - INTERVAL '90 seconds') as is_fresh, heartbeat::TEXT, process_id FROM scheduler_election WHERE user_id = $1 AND role = 'leader'", &[ParameterValue::Str(uid)])?;
-    if !rs.rows.is_empty() { active = match rs.rows[0][0] { DbValue::Boolean(b) => b, _ => false }; last = db_to_str(&rs.rows[0][1]); pid = db_to_str(&rs.rows[0][2]); }
+    let rs = conn.query("SELECT (heartbeat > CURRENT_TIMESTAMP - INTERVAL '90 seconds') as is_fresh, heartbeat::TEXT, process_id FROM scheduler_election WHERE user_id = $1 AND role = 'leader'", &[ParameterValue::Str(uid)]).await?.collect().await?;
+    if !rs.is_empty() { active = match &rs[0][0] { DbValue::Boolean(b) => *b, _ => false }; last = match &rs[0][1] { DbValue::Str(s) => s.clone(), _ => "unknown".to_string() }; pid = match &rs[0][2] { DbValue::Str(s) => s.clone(), _ => "unknown".to_string() }; }
     json_response(200, &HealthResp { status: "ok".to_string(), home_server_active: active, leader_pid: pid, last_seen: last })
 }
 
-async fn handle_heartbeat_post(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let body = req.body();
-    let b: serde_json::Value = serde_json::from_slice(body)?;
+async fn handle_heartbeat_post(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let body = req.into_body().collect().await.map_err(|e| anyhow::anyhow!("Body: {:?}", e))?.to_bytes();
+    let b: serde_json::Value = serde_json::from_slice(&body)?;
     let pid = b.get("process_id").and_then(|v| v.as_str()).unwrap_or("unknown");
     let role = b.get("role").and_then(|v| v.as_str()).unwrap_or("leader");
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-    conn.execute("INSERT INTO scheduler_election (user_id, role, process_id, heartbeat) VALUES ($1, $2, $3, CURRENT_TIMESTAMP) ON CONFLICT (user_id, role) DO UPDATE SET heartbeat = EXCLUDED.heartbeat, process_id = EXCLUDED.process_id", &[ParameterValue::Str(uid), ParameterValue::Str(role.to_string()), ParameterValue::Str(pid.to_string())])?;
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    conn.execute("INSERT INTO scheduler_election (user_id, role, process_id, heartbeat) VALUES ($1, $2, $3, CURRENT_TIMESTAMP) ON CONFLICT (user_id, role) DO UPDATE SET heartbeat = EXCLUDED.heartbeat, process_id = EXCLUDED.process_id", &[ParameterValue::Str(uid), ParameterValue::Str(role.to_string()), ParameterValue::Str(pid.to_string())]).await?;
     json_response(200, &StatusResponse { status: "success".to_string(), message: "Heartbeat received".to_string() })
 }
 
-async fn handle_multiplier_post(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let body = req.body();
+async fn handle_multiplier_post(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let body = req.into_body().collect().await.map_err(|e| anyhow::anyhow!("Body: {:?}", e))?.to_bytes();
     #[derive(Deserialize)] struct MultReq { name: String, multiplier: f64 }
-    let data: MultReq = serde_json::from_slice(body)?;
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-    match conn.execute("UPDATE language_stats SET pump_multiplier = $1::FLOAT8::NUMERIC WHERE user_id = $2 AND language_name = $3", &[ParameterValue::Floating64(data.multiplier), ParameterValue::Str(uid), ParameterValue::Str(data.name.to_uppercase())]) {
+    let data: MultReq = serde_json::from_slice(&body)?;
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    match conn.execute("UPDATE language_stats SET pump_multiplier = $1::FLOAT8::NUMERIC WHERE user_id = $2 AND language_name = $3", &[ParameterValue::Floating64(data.multiplier), ParameterValue::Str(uid), ParameterValue::Str(data.name.to_uppercase())]).await {
         Ok(_) => Ok(text_response(200, "Multiplier updated")?),
         Err(e) => json_response(500, &StatusResponse { status: "error".to_string(), message: format!("DB: {}", e) })
     }
 }
 
-async fn handle_languages_get(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-     let rs = conn.query("SELECT language_name, current_reviews, tomorrow_reviews, next_7_days_reviews, daily_rate::FLOAT8, safebuf, derail_risk, pump_multiplier::FLOAT8, beeminder_slug, daily_completions FROM language_stats WHERE user_id = $1 ORDER BY (beeminder_slug != '' AND beeminder_slug IS NOT NULL) DESC, language_name ASC", &[ParameterValue::Str(uid)])?;
+async fn handle_languages_get(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let rs = conn.query("SELECT language_name, current_reviews, tomorrow_reviews, next_7_days_reviews, daily_rate::FLOAT8, safebuf, derail_risk, pump_multiplier::FLOAT8, beeminder_slug, daily_completions FROM language_stats WHERE user_id = $1 ORDER BY (beeminder_slug != '' AND beeminder_slug IS NOT NULL) DESC, language_name ASC", &[ParameterValue::Str(uid)]).await?.collect().await?;
     #[derive(Serialize)] struct LangStat { name: String, current: i32, tomorrow: i32, next_7_days: i32, daily_rate: f64, safebuf: i32, derail_risk: String, pump_multiplier: Option<f64>, daily_completions: i32, goal_met: bool, absolute_target: i32, has_goal: bool, target_flow_rate: Option<f64>, outstanding_debt: Option<i32> }
     let mut langs = Vec::new();
-    for r in &rs.rows {
+    for r in &rs {
         let name = db_to_str(&r[0]);
         let cur = db_to_i32(&r[1]);
         let tom = db_to_i32(&r[2]);
@@ -274,33 +232,31 @@ async fn handle_languages_get(req: Request) -> anyhow::Result<Response> {
     json_response(200, &LangResp { languages: langs })
 }
 
-async fn handle_budget_get(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-     let rs = conn.query("SELECT remaining_budget FROM budget_tracking WHERE user_id = $1 LIMIT 1", &[ParameterValue::Str(uid)])?;
-    let budget = if rs.rows.is_empty() { 0.0 } else { db_to_f64(&rs.rows[0][0]) };
+async fn handle_budget_get(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let rs = conn.query("SELECT remaining_budget FROM budget_tracking WHERE user_id = $1 LIMIT 1", &[ParameterValue::Str(uid)]).await?.collect().await?;
+    let budget = if rs.is_empty() { 0.0 } else { db_to_f64(&rs[0][0]) };
     #[derive(Serialize)] struct BudgetResp { remaining_budget: f64 }
     json_response(200, &BudgetResp { remaining_budget: budget })
 }
 
-async fn handle_walks_post(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let body = req.body();
+async fn handle_walks_post(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let body = req.into_body().collect().await.map_err(|e| anyhow::anyhow!("Body: {:?}", e))?.to_bytes();
     #[derive(Deserialize)] struct WalkSum { start_time: String, end_time: String, step_count: i32, distance_meters: f64, distance_source: String, confidence_score: f64, gps_route_points: i32 }
-    let walk: WalkSum = serde_json::from_slice(body)?;
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-    let _ = conn.execute("INSERT INTO users (pocket_id_sub, beeminder_token_encrypted, beeminder_goal) VALUES ($1, '', 'bike') ON CONFLICT DO NOTHING", &[ParameterValue::Str(uid.clone())]);
-    let prev = conn.query("SELECT distance_meters FROM walk_inferences WHERE user_id = $1 AND start_time = $2", &[ParameterValue::Str(uid.clone()), ParameterValue::Str(walk.start_time.clone())])?;
-    let prev_dist: f64 = if !prev.rows.is_empty() { match &prev.rows[0][0] { DbValue::Str(s) => s.parse().unwrap_or(0.0), _ => 0.0 } } else { 0.0 };
+    let walk: WalkSum = serde_json::from_slice(&body)?;
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let _ = conn.execute("INSERT INTO users (pocket_id_sub, beeminder_token_encrypted, beeminder_goal) VALUES ($1, '', 'bike') ON CONFLICT DO NOTHING", &[ParameterValue::Str(uid.clone())]).await;
+    let prev = conn.query("SELECT distance_meters FROM walk_inferences WHERE user_id = $1 AND start_time = $2", &[ParameterValue::Str(uid.clone()), ParameterValue::Str(walk.start_time.clone())]).await?.collect().await?;
+    let prev_dist: f64 = if !prev.is_empty() { match &prev[0][0] { DbValue::Str(s) => s.parse().unwrap_or(0.0), _ => 0.0 } } else { 0.0 };
     let delta = walk.distance_meters - prev_dist;
-    conn.execute("INSERT INTO walk_inferences (user_id, start_time, end_time, step_count, distance_meters, distance_source, confidence_score, gps_route_points) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (user_id, start_time) DO UPDATE SET end_time = EXCLUDED.end_time, step_count = EXCLUDED.step_count, distance_meters = EXCLUDED.distance_meters, distance_source = EXCLUDED.distance_source, confidence_score = EXCLUDED.confidence_score, gps_route_points = EXCLUDED.gps_route_points", &[ParameterValue::Str(uid.clone()), ParameterValue::Str(walk.start_time.clone()), ParameterValue::Str(walk.end_time.clone()), ParameterValue::Str(walk.step_count.to_string()), ParameterValue::Str(walk.distance_meters.to_string()), ParameterValue::Str(walk.distance_source.clone()), ParameterValue::Str(walk.confidence_score.to_string()), ParameterValue::Str(walk.gps_route_points.to_string())])?;
-    let token = conn.query("SELECT beeminder_goal FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())])?;
-    if !token.rows.is_empty() && delta > 200.0 {
-        let goal = match &token.rows[0][0] { DbValue::Str(s) if !s.is_empty() => s.clone(), _ => "bike".to_string() };
+    conn.execute("INSERT INTO walk_inferences (user_id, start_time, end_time, step_count, distance_meters, distance_source, confidence_score, gps_route_points) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (user_id, start_time) DO UPDATE SET end_time = EXCLUDED.end_time, step_count = EXCLUDED.step_count, distance_meters = EXCLUDED.distance_meters, distance_source = EXCLUDED.distance_source, confidence_score = EXCLUDED.confidence_score, gps_route_points = EXCLUDED.gps_route_points", &[ParameterValue::Str(uid.clone()), ParameterValue::Str(walk.start_time.clone()), ParameterValue::Str(walk.end_time.clone()), ParameterValue::Str(walk.step_count.to_string()), ParameterValue::Str(walk.distance_meters.to_string()), ParameterValue::Str(walk.distance_source.clone()), ParameterValue::Str(walk.confidence_score.to_string()), ParameterValue::Str(walk.gps_route_points.to_string())]).await?;
+    let token = conn.query("SELECT beeminder_goal FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
+    if !token.is_empty() && delta > 200.0 {
+        let goal = match &token[0][0] { DbValue::Str(s) if !s.is_empty() => s.clone(), _ => "bike".to_string() };
         let miles = ((walk.distance_meters / 1609.34) * 1000.0).round() / 1000.0;
         let requestid = format!("{}-{}-{}-{}", uid, goal, walk.start_time, walk.distance_meters);
         let _ = push_to_beeminder_idempotent(&uid, &goal, miles, "Synced via Spin (Cumulative)", &requestid, &conn).await;
@@ -308,134 +264,132 @@ async fn handle_walks_post(req: Request) -> anyhow::Result<Response> {
     json_response(201, &StatusResponse { status: "success".to_string(), message: "Walk ingested".to_string() })
 }
 
-async fn handle_trigger_reminders_post(_req: Request) -> anyhow::Result<Response> {
-    let sid = variables::get("twilio_account_sid")?;
-    let _tok = decrypt_token(&variables::get("twilio_auth_token_encrypted")?).await?;
-    let from = variables::get("twilio_from_number")?;
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-     let rs = conn.query("SELECT pocket_id_sub, phone_number_encrypted, COALESCE(timezone, 'UTC'), COALESCE(notification_prefs::TEXT, '{}') FROM users WHERE phone_number_encrypted IS NOT NULL AND phone_number_encrypted != '' AND autonomous_sync_enabled = true", &[])?;
+async fn handle_trigger_reminders_post(_req: Request) -> anyhow::Result<Response<String>> {
+    let sid = variables::get("twilio_account_sid").await?;
+    let _tok = decrypt_token(&variables::get("twilio_auth_token_encrypted").await?).await?;
+    let from = variables::get("twilio_from_number").await?;
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let rs = conn.query("SELECT pocket_id_sub, phone_number_encrypted, COALESCE(timezone, 'UTC'), COALESCE(notification_prefs::TEXT, '{}') FROM users WHERE phone_number_encrypted IS NOT NULL AND phone_number_encrypted != '' AND autonomous_sync_enabled = true", &[]).await?.collect().await?;
     let (mut sent, mut errors, now) = (0, 0, chrono::Utc::now());
     let (today, epoch) = (now.format("%Y-%m-%d").to_string(), now.timestamp() as u64);
-    for r in &rs.rows {
-        let (uid, ph_enc, tz, pref_j) = (db_to_str(&r[0]), db_to_str(&r[1]), db_to_str(&r[2]), db_to_str(&r[3]));
+    for r in &rs {
+        let (uid, ph_enc, tz, pref_j) = (match &r[0] { DbValue::Str(s) => s.clone(), _ => continue }, match &r[1] { DbValue::Str(s) => s.clone(), _ => continue }, match &r[2] { DbValue::Str(s) => s.clone(), _ => "UTC".to_string() }, match &r[3] { DbValue::Str(s) => s.clone(), _ => "{}".to_string() });
         let pref: NotificationPrefs = serde_json::from_str(&pref_j).unwrap_or_default();
-        let s_rs = conn.query("SELECT step_count FROM walk_inferences WHERE user_id = $1 AND start_time >= $2 ORDER BY start_time ASC", &[ParameterValue::Str(uid.clone()), ParameterValue::Str(today.clone())])?;
-        let steps = aggregate_step_count(&s_rs.rows);
-        let m_rs = conn.query("SELECT sent_at::TEXT FROM message_log WHERE user_id = $1 AND type = 'walk_reminder' ORDER BY sent_at DESC LIMIT 1", &[ParameterValue::Str(uid.clone())])?;
-        let ms = m_rs.rows.first().and_then(|mr| match &mr[0] { DbValue::Str(s) if !s.is_empty() => Some(s.as_str()), _ => None });
+        let s_rs = conn.query("SELECT step_count FROM walk_inferences WHERE user_id = $1 AND start_time >= $2 ORDER BY start_time ASC", &[ParameterValue::Str(uid.clone()), ParameterValue::Str(today.clone())]).await?.collect().await?;
+        let steps = aggregate_step_count(&s_rs);
+        let m_rs = conn.query("SELECT sent_at::TEXT FROM message_log WHERE user_id = $1 AND type = 'walk_reminder' ORDER BY sent_at DESC LIMIT 1", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
+        let ms = m_rs.first().and_then(|mr| match &mr[0] { DbValue::Str(s) if !s.is_empty() => Some(s.as_str()), _ => None });
         let mins = ms.and_then(|s| chrono::DateTime::parse_from_rfc3339(s).or_else(|_| chrono::DateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f%z")).ok().map(|dt| epoch.saturating_sub(dt.timestamp() as u64) / 60));
         if !should_dispatch(local_hour_from_timezone(&tz, &now), steps, mins, &pref) { continue; }
-        let hb_rs = conn.query("SELECT EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - heartbeat)) / 60 FROM scheduler_election WHERE user_id = $1 AND role = 'android_client' ORDER BY heartbeat DESC LIMIT 1", &[ParameterValue::Str(uid.clone())])?;
-        if hb_rs.rows.first().and_then(|hr| match hr[0] { DbValue::Floating64(f) => Some(f as u64), _ => None }).map_or(false, |m| m < 240) { continue; }
+        let hb_rs = conn.query("SELECT EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - heartbeat)) / 60 FROM scheduler_election WHERE user_id = $1 AND role = 'android_client' ORDER BY heartbeat DESC LIMIT 1", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
+        if hb_rs.first().and_then(|hr| match &hr[0] { DbValue::Floating64(f) => Some(*f as u64), _ => None }).map_or(false, |m| m < 240) { continue; }
         let ph = decrypt_token(&ph_enc).await?;
         match send_twilio_sms(&sid, &_tok, &from, &ph, "Mecris: Time for a walk! Reply YES to log 1 mile.").await {
-            Ok(_) => { let _ = conn.execute("INSERT INTO message_log (user_id, type, sent_at, compliance_status) VALUES ($1, 'walk_reminder', CURRENT_TIMESTAMP, 'sent')", &[ParameterValue::Str(uid.clone())]); sent += 1; }
+            Ok(_) => { let _ = conn.execute("INSERT INTO message_log (user_id, type, sent_at, compliance_status) VALUES ($1, 'walk_reminder', CURRENT_TIMESTAMP, 'sent')", &[ParameterValue::Str(uid.clone())]).await; sent += 1; }
             Err(_) => { errors += 1; }
         }
     }
     json_response(200, &format!("Sent {} reminders, {} errors", sent, errors))
 }
 
-async fn handle_failover_sync_post(_req: Request) -> anyhow::Result<Response> {
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-     let rs = conn.query("SELECT pocket_id_sub, EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - COALESCE(last_autonomous_sync, '1970-01-01'::TIMESTAMPTZ))/60 FROM users WHERE autonomous_sync_enabled = true", &[])?;
+async fn handle_failover_sync_post(_req: Request) -> anyhow::Result<Response<String>> {
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let rs = conn.query("SELECT pocket_id_sub, EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - COALESCE(last_autonomous_sync, '1970-01-01'::TIMESTAMPTZ))/60 FROM users WHERE autonomous_sync_enabled = true", &[]).await?.collect().await?;
     let mut success = 0;
-    for r in &rs.rows {
-        let uid = db_to_str(&r[0]);
-        let mins = match r[1] { DbValue::Floating64(f) => f, _ => 0.0 };
+    for r in &rs {
+        let uid = match &r[0] { DbValue::Str(s) => s.clone(), _ => continue };
+        let mins = match &r[1] { DbValue::Floating64(f) => *f, _ => 0.0 };
         if mins > 1440.0 { if let Ok(_) = run_clozemaster_scraper(&db, &uid).await { success += 1; } }
     }
     json_response(200, &format!("Failover sync: {} success", success))
 }
 
-async fn handle_request_phone_verification_post(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let body = req.body();
+async fn handle_request_phone_verification_post(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let body = req.into_body().collect().await.map_err(|_| anyhow::anyhow!("body"))?.to_bytes();
     #[derive(Deserialize)] struct Req { phone_number: String }
-    let vr: Req = serde_json::from_slice(body)?;
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
+    let vr: Req = serde_json::from_slice(&body)?;
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
     let mut rb = [0u8; 4]; getrandom::getrandom(&mut rb).map_err(|e| anyhow::anyhow!("getrandom: {}", e))?;
     let code = format!("{:06}", (u32::from_be_bytes(rb) % 1000000));
     let hash = hex::encode(Sha256::digest(code.as_bytes()));
     let exp = (chrono::Utc::now() + chrono::Duration::minutes(15)).to_rfc3339();
-    conn.execute("INSERT INTO phone_verifications (user_id, code_hash, expires_at) VALUES ($1, $2, $3::TIMESTAMPTZ) ON CONFLICT (user_id) DO UPDATE SET code_hash = EXCLUDED.code_hash, expires_at = EXCLUDED.expires_at, attempts = 0", &[ParameterValue::Str(uid.clone()), ParameterValue::Str(hash), ParameterValue::Str(exp)])?;
-    let sid = variables::get("twilio_account_sid")?;
-    let auth = decrypt_token(&variables::get("twilio_auth_token_encrypted")?).await?;
-    let from = variables::get("twilio_from_number")?;
+    conn.execute("INSERT INTO phone_verifications (user_id, code_hash, expires_at) VALUES ($1, $2, $3::TIMESTAMPTZ) ON CONFLICT (user_id) DO UPDATE SET code_hash = EXCLUDED.code_hash, expires_at = EXCLUDED.expires_at, attempts = 0", &[ParameterValue::Str(uid.clone()), ParameterValue::Str(hash), ParameterValue::Str(exp)]).await?;
+    let sid = variables::get("twilio_account_sid").await?;
+    let auth = decrypt_token(&variables::get("twilio_auth_token_encrypted").await?).await?;
+    let from = variables::get("twilio_from_number").await?;
     send_twilio_sms(&sid, &auth, &from, &vr.phone_number, &format!("Mecris code: {}", code)).await?;
     json_response(200, &"Verification code sent")
 }
 
-async fn handle_confirm_phone_verification_post(req: Request) -> anyhow::Result<Response> {
-    let auth = req.header("authorization").or_else(|| req.header("Authorization")).and_then(|v| std::str::from_utf8(v.as_bytes()).ok());
-    let uid = match extract_user_id(auth).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
-    let body = req.body();
+async fn handle_confirm_phone_verification_post(req: Request) -> anyhow::Result<Response<String>> {
+    let uid = match extract_user_id(req.headers().get("authorization")).await { Some(id) => id, None => return Ok(text_response(401, "Unauthorized")?) };
+    let body = req.into_body().collect().await.map_err(|_| anyhow::anyhow!("body"))?.to_bytes();
     #[derive(Deserialize)] struct Conf { code: String }
-    let cr: Conf = serde_json::from_slice(body)?;
-    let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-     let conn = Connection::open(&db)?;
-     let rs = conn.query("SELECT code_hash, CAST(EXTRACT(EPOCH FROM expires_at) AS BIGINT), attempts FROM phone_verifications WHERE user_id = $1", &[ParameterValue::Str(uid.clone())])?;
-    if rs.rows.is_empty() { return Ok(text_response(400, "No request")?); }
-    let db_hash = db_to_str(&rs.rows[0][0]);
-    let exp = match rs.rows[0][1] { DbValue::Int64(i) => i as u64, _ => 0 };
-    let att = db_to_i32(&rs.rows[0][2]);
+    let cr: Conf = serde_json::from_slice(&body)?;
+    let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+    let conn = Connection::open(&db).await?;
+    let rs = conn.query("SELECT code_hash, CAST(EXTRACT(EPOCH FROM expires_at) AS BIGINT), attempts FROM phone_verifications WHERE user_id = $1", &[ParameterValue::Str(uid.clone())]).await?.collect().await?;
+    if rs.is_empty() { return Ok(text_response(400, "No request")?); }
+    let db_hash = match &rs[0][0] { DbValue::Str(s) => s, _ => "" };
+    let exp = match &rs[0][1] { DbValue::Int64(i) => *i as u64, _ => 0 };
+    let att = match &rs[0][2] { DbValue::Int32(i) => *i, _ => 0 };
     if att >= 5 { return Ok(text_response(429, "Too many attempts")?); }
     if chrono::Utc::now().timestamp() as u64 > exp { return Ok(text_response(400, "Expired")?); }
     if hex::encode(Sha256::digest(cr.code.as_bytes())) == db_hash {
-        conn.execute("UPDATE users SET phone_verified = true WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())])?;
-        conn.execute("DELETE FROM phone_verifications WHERE user_id = $1", &[ParameterValue::Str(uid.clone())])?;
+        conn.execute("UPDATE users SET phone_verified = true WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.clone())]).await?;
+        conn.execute("DELETE FROM phone_verifications WHERE user_id = $1", &[ParameterValue::Str(uid.clone())]).await?;
         json_response(200, &"Phone verified")
     } else {
-        conn.execute("UPDATE phone_verifications SET attempts = attempts + 1 WHERE user_id = $1", &[ParameterValue::Str(uid.clone())])?;
+        conn.execute("UPDATE phone_verifications SET attempts = attempts + 1 WHERE user_id = $1", &[ParameterValue::Str(uid.clone())]).await?;
         text_response(400, "Invalid code")
     }
 }
 
-async fn handle_twilio_webhook_post(req: Request) -> anyhow::Result<Response> {
-    let _tok = decrypt_token(&variables::get("twilio_auth_token_encrypted")?).await?;
-    let body = req.body();
-    let body_str = std::str::from_utf8(body).unwrap_or("");
+async fn handle_twilio_webhook_post(req: Request) -> anyhow::Result<Response<String>> {
+    let _tok = decrypt_token(&variables::get("twilio_auth_token_encrypted").await?).await?;
+    let body = req.into_body().collect().await.map_err(|_| anyhow::anyhow!("body"))?.to_bytes();
+    let body_str = std::str::from_utf8(&body).unwrap_or("");
     let from_num = body_str.split('&').find_map(|p| { let mut i = p.splitn(2, '='); if i.next() == Some("From") { Some(urlencoding::decode(&i.next()?.replace('+', " ")).unwrap_or_default().into_owned()) } else { None } }).unwrap_or_default();
     if body_str.to_uppercase().contains("YES") {
-        let db = match variables::get("db_url").or_else(|_| variables::get("neon_db_url")) { Ok(v) if !v.is_empty() => v, _ => return Err(anyhow::anyhow!("DB URL")) };
-         let conn = Connection::open(&db)?;
-         let rs = conn.query("SELECT pocket_id_sub, phone_number_encrypted, beeminder_goal FROM users WHERE phone_number_encrypted IS NOT NULL", &[])?;
-        for r in &rs.rows {
-            let (uid, ph_enc, goal) = (db_to_str(&r[0]), db_to_str(&r[1]), db_to_str(&r[2]));
+        let db = match variables::get("db_url").await { Ok(v) if !v.is_empty() => v, _ => variables::get("neon_db_url").await? };
+        let conn = Connection::open(&db).await?;
+        let rs = conn.query("SELECT pocket_id_sub, phone_number_encrypted, beeminder_goal FROM users WHERE phone_number_encrypted IS NOT NULL", &[]).await?.collect().await?;
+        for r in &rs {
+            let (uid, ph_enc, goal) = (match &r[0] { DbValue::Str(s) => s.clone(), _ => continue }, match &r[1] { DbValue::Str(s) => s.clone(), _ => continue }, match &r[2] { DbValue::Str(s) => s.clone(), _ => "bike".to_string() });
             if let Ok(ph) = decrypt_token(&ph_enc).await {
                 let clean = |s: &str| s.chars().filter(|c| c.is_digit(10)).collect::<String>();
                 if !ph.is_empty() && clean(&ph) == clean(&from_num) {
                     let requestid = format!("{}-{}-{}-sms", uid, goal, chrono::Utc::now().format("%Y-%m-%d"));
                     let _ = push_to_beeminder_idempotent(&uid, &goal, 1.0, "Walk logged via SMS", &requestid, &conn).await;
-                    let _ = conn.execute("INSERT INTO message_log (user_id, type, sent_at, compliance_status) VALUES ($1, 'walk_ack', CURRENT_TIMESTAMP, 'received')", &[ParameterValue::Str(uid)]);
+                    let _ = conn.execute("INSERT INTO message_log (user_id, type, sent_at, compliance_status) VALUES ($1, 'walk_ack', CURRENT_TIMESTAMP, 'received')", &[ParameterValue::Str(uid)]).await;
                 }
             }
         }
     }
-    Ok(Response::builder().status(200).header("content-type", "text/xml").body(r#"<?xml version="1.0" encoding="UTF-8"?><Response></Response>"#.to_string().into_bytes()).build())
+    Ok(Response::builder().status(200).header("content-type", "text/xml").body(r#"<?xml version="1.0" encoding="UTF-8"?><Response></Response>"#.to_string())?)
 }
 
 async fn run_clozemaster_scraper(db: &str, uid: &str) -> anyhow::Result<()> {
-    let conn = Connection::open(db)?;
-     let rs = conn.query("SELECT clozemaster_email_encrypted, clozemaster_password_encrypted FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.to_string())])?;
-    if rs.rows.is_empty() { return Err(anyhow::anyhow!("User not found")); }
-    let email = decrypt_token(&db_to_str(&rs.rows[0][0])).await?;
-    let pass = decrypt_token(&db_to_str(&rs.rows[0][1])).await?;
+    let conn = Connection::open(db).await?;
+    let rs = conn.query("SELECT clozemaster_email_encrypted, clozemaster_password_encrypted FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.to_string())]).await?.collect().await?;
+    if rs.is_empty() { return Err(anyhow::anyhow!("User not found")); }
+    let email = decrypt_token(match &rs[0][0] { DbValue::Str(s) => s, _ => "" }).await?;
+    let pass = decrypt_token(match &rs[0][1] { DbValue::Str(s) => s, _ => "" }).await?;
     let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
-    let res: Response = spin_sdk::http::send::<_, Response>(Request::builder().method(Method::Get).uri("https://www.clozemaster.com/login").header("User-Agent", ua).build()).await?;
-    let sess = res.header("set-cookie").and_then(|v| std::str::from_utf8(v.as_bytes()).ok()).unwrap_or("").split(';').next().unwrap_or("").to_string();
-    let body = String::from_utf8(res.body().to_vec())?;
+    let res = spin_sdk::http::send(Request::builder().method(Method::GET).uri("https://www.clozemaster.com/login").header("User-Agent", ua).body(String::new())?).await?;
+    let sess = res.headers().get("set-cookie").and_then(|v| v.to_str().ok()).unwrap_or("").split(';').next().unwrap_or("").to_string();
+    let body = String::from_utf8(res.into_body().collect().await.map_err(|_| anyhow::anyhow!("body"))?.to_bytes().to_vec())?;
     let csrf = regex::Regex::new(r#"name="authenticity_token" value="([^"]*)""#)?.captures(&body).and_then(|cap| cap.get(1)).map(|m| m.as_str()).ok_or_else(|| anyhow::anyhow!("CSRF"))?;
     let login_body = format!("user%5Blogin%5D={}&user%5Bpassword%5D={}&authenticity_token={}&commit=Log+In", urlencoding::encode(&email), urlencoding::encode(&pass), urlencoding::encode(csrf));
-    let res: Response = spin_sdk::http::send::<_, Response>(Request::builder().method(Method::Post).uri("https://www.clozemaster.com/login").header("content-type", "application/x-www-form-urlencoded").header("User-Agent", ua).header("Cookie", &sess).body(login_body.into_bytes()).build()).await?;
-    let sess = res.header("set-cookie").and_then(|v| std::str::from_utf8(v.as_bytes()).ok()).unwrap_or(&sess).split(';').next().unwrap_or(&sess).to_string();
-    let mut res: Response = spin_sdk::http::send::<_, Response>(Request::builder().method(Method::Get).uri("https://www.clozemaster.com/dashboard").header("User-Agent", ua).header("Cookie", &sess).build()).await?;
-    if *res.status() == 302 { if let Some(loc) = res.header("location").and_then(|v| std::str::from_utf8(v.as_bytes()).ok()) { let url = if loc.starts_with('/') { format!("https://www.clozemaster.com{}", loc) } else { loc.to_string() }; res = spin_sdk::http::send::<_, Response>(Request::builder().method(Method::Get).uri(url).header("User-Agent", ua).header("Cookie", &sess).build()).await?; } }
-    let body = String::from_utf8(res.body().to_vec())?;
+    let res = spin_sdk::http::send(Request::builder().method(Method::POST).uri("https://www.clozemaster.com/login").header("content-type", "application/x-www-form-urlencoded").header("User-Agent", ua).header("Cookie", &sess).body(login_body)?).await?;
+    let sess = res.headers().get("set-cookie").and_then(|v| v.to_str().ok()).unwrap_or(&sess).split(';').next().unwrap_or(&sess).to_string();
+    let mut res = spin_sdk::http::send(Request::builder().method(Method::GET).uri("https://www.clozemaster.com/dashboard").header("User-Agent", ua).header("Cookie", &sess).body(String::new())?).await?;
+    if res.status().as_u16() == 302 { if let Some(loc) = res.headers().get("location").and_then(|v| v.to_str().ok()) { let url = if loc.starts_with('/') { format!("https://www.clozemaster.com{}", loc) } else { loc.to_string() }; res = spin_sdk::http::send(Request::builder().method(Method::GET).uri(url).header("User-Agent", ua).header("Cookie", &sess).body(String::new())?).await?; } }
+    let body = String::from_utf8(res.into_body().collect().await.map_err(|_| anyhow::anyhow!("body"))?.to_bytes().to_vec())?;
     let props_escaped = regex::Regex::new(r#"data-react-props="([^"]*)""#)?.captures(&body).and_then(|cap| cap.get(1)).map(|m| m.as_str()).ok_or_else(|| anyhow::anyhow!("Props"))?;
     let fresh_csrf = regex::Regex::new(r#"<meta name="csrf-token" content="([^"]*)""#)?.captures(&body).and_then(|cap| cap.get(1)).map(|m| m.as_str()).unwrap_or(csrf);
     let props: serde_json::Value = serde_json::from_str(&html_escape::decode_html_entities(props_escaped))?;
@@ -448,8 +402,9 @@ async fn run_clozemaster_scraper(db: &str, uid: &str) -> anyhow::Result<()> {
             let tod = p.get("numPointsToday").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
             let (lang, beem) = match slug_name.as_str() { 
                 "ara-eng" => ("ARABIC", "reviewstack"), 
-                "ell-eng" => ("GREEK", "ellinika"), 
+                "ell-eng" => ("GREEK", ""), 
                 "gle-eng" => ("IRISH", ""),
+                "tok-eng" => ("TOKI PONA", ""),
                 "lit-eng" => ("LITHUANIAN", ""),
                 "swh-eng" => ("SWAHILI", ""),
                 _ => (slug_name.as_str(), ""), 
@@ -457,19 +412,19 @@ async fn run_clozemaster_scraper(db: &str, uid: &str) -> anyhow::Result<()> {
             let (mut tom, mut n7) = (0, 0);
             if id > 0 {
                 let api_url = format!("https://www.clozemaster.com/api/v1/lp/{}/more-stats", id);
-                if let Ok(api_res) = spin_sdk::http::send::<_, Response>(Request::builder().method(Method::Get).uri(api_url).header("User-Agent", ua).header("Cookie", &sess).header("X-CSRF-Token", fresh_csrf).header("X-Requested-With", "XMLHttpRequest").build()).await {
-                    let api_json: serde_json::Value = serde_json::from_str(&String::from_utf8(api_res.body().to_vec())?)?;
+                if let Ok(api_res) = spin_sdk::http::send(Request::builder().method(Method::GET).uri(api_url).header("User-Agent", ua).header("Cookie", &sess).header("X-CSRF-Token", fresh_csrf).header("X-Requested-With", "XMLHttpRequest").body(String::new())?).await {
+                    let api_json: serde_json::Value = serde_json::from_str(&String::from_utf8(api_res.into_body().collect().await.map_err(|_| anyhow::anyhow!("body"))?.to_bytes().to_vec())?)?;
                     if let Some(f) = api_json.get("reviewForecast").and_then(|v| v.as_array()) { if !f.is_empty() {
                         let parse = |v: &serde_json::Value| v.get("count").and_then(|v| v.as_i64()).unwrap_or_else(|| v.as_i64().unwrap_or(0)) as i32;
                         tom = parse(&f[0]); n7 = f.iter().take(7).map(parse).sum();
                     } }
                 }
             }
-             let rs = conn.query("SELECT current_reviews, (beeminder_last_sync AT TIME ZONE 'UTC')::TEXT FROM language_stats WHERE user_id = $1 AND language_name = $2", &[ParameterValue::Str(uid.to_string()), ParameterValue::Str(lang.to_uppercase())])?;
+            let rs = conn.query("SELECT current_reviews, (beeminder_last_sync AT TIME ZONE 'UTC')::TEXT FROM language_stats WHERE user_id = $1 AND language_name = $2", &[ParameterValue::Str(uid.to_string()), ParameterValue::Str(lang.to_uppercase())]).await?.collect().await?;
             let (mut prev, mut lsync) = (-1, String::new());
-            if !rs.rows.is_empty() { prev = db_to_i32(&rs.rows[0][0]); lsync = db_to_str(&rs.rows[0][1]); }
+            if !rs.is_empty() { prev = match &rs[0][0] { DbValue::Int32(i) => *i, _ => -1 }; lsync = match &rs[0][1] { DbValue::Str(s) => s.clone(), _ => String::new() }; }
             let mut compl = tod; if lang == "ARABIC" { compl = (tod as f64 / 16.0) as i32; }
-            conn.execute("INSERT INTO language_stats (user_id, language_name, current_reviews, tomorrow_reviews, next_7_days_reviews, beeminder_slug, daily_completions, last_points, total_points, last_updated) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, CURRENT_TIMESTAMP) ON CONFLICT (user_id, language_name) DO UPDATE SET current_reviews = EXCLUDED.current_reviews, tomorrow_reviews = EXCLUDED.tomorrow_reviews, next_7_days_reviews = EXCLUDED.next_7_days_reviews, beeminder_slug = COALESCE(NULLIF(EXCLUDED.beeminder_slug, ''), language_stats.beeminder_slug), daily_completions = EXCLUDED.daily_completions, last_points = EXCLUDED.last_points, total_points = EXCLUDED.total_points, last_updated = CURRENT_TIMESTAMP", &[ParameterValue::Str(uid.to_string()), ParameterValue::Str(lang.to_uppercase()), ParameterValue::Int32(cur), ParameterValue::Int32(tom), ParameterValue::Int32(n7), ParameterValue::Str(beem.to_string()), ParameterValue::Int32(compl), ParameterValue::Int32(tot), ParameterValue::Int32(tot)])?;
+            conn.execute("INSERT INTO language_stats (user_id, language_name, current_reviews, tomorrow_reviews, next_7_days_reviews, beeminder_slug, daily_completions, last_points, total_points, last_updated) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, CURRENT_TIMESTAMP) ON CONFLICT (user_id, language_name) DO UPDATE SET current_reviews = EXCLUDED.current_reviews, tomorrow_reviews = EXCLUDED.tomorrow_reviews, next_7_days_reviews = EXCLUDED.next_7_days_reviews, beeminder_slug = EXCLUDED.beeminder_slug, daily_completions = EXCLUDED.daily_completions, last_points = EXCLUDED.last_points, total_points = EXCLUDED.total_points, last_updated = CURRENT_TIMESTAMP", &[ParameterValue::Str(uid.to_string()), ParameterValue::Str(lang.to_uppercase()), ParameterValue::Int32(cur), ParameterValue::Int32(tom), ParameterValue::Int32(n7), ParameterValue::Str(beem.to_string()), ParameterValue::Int32(compl), ParameterValue::Int32(tot), ParameterValue::Int32(tot)]).await?;
             if !beem.is_empty() {
                 let now_ny = chrono::Utc::now().with_timezone(&chrono_tz::America::New_York);
                 let today_ny = now_ny.format("%Y-%m-%d").to_string();
@@ -477,11 +432,11 @@ async fn run_clozemaster_scraper(db: &str, uid: &str) -> anyhow::Result<()> {
                 if cur != prev || !already_synced {
                     let comment = format!("Auto-synced from Clozemaster (Cloud) at {} | Tomorrow: {} | 7-day: {}", now_ny.format("%Y-%m-%d %H:%M"), tom, n7);
                     let rid = format!("{}-{}-{}-{}", uid, beem, today_ny, cur);
-                    if let Ok(_) = push_to_beeminder_idempotent(uid, beem, cur as f64, &comment, &rid, &conn).await { conn.execute("UPDATE language_stats SET beeminder_last_sync = CURRENT_TIMESTAMP WHERE user_id = $1 AND language_name = $2", &[ParameterValue::Str(uid.to_string()), ParameterValue::Str(lang.to_uppercase())])?; }
+                    if let Ok(_) = push_to_beeminder_idempotent(uid, beem, cur as f64, &comment, &rid, &conn).await { conn.execute("UPDATE language_stats SET beeminder_last_sync = CURRENT_TIMESTAMP WHERE user_id = $1 AND language_name = $2", &[ParameterValue::Str(uid.to_string()), ParameterValue::Str(lang.to_uppercase())]).await?; }
                 }
                 if let Ok((mut sb, mut risk, rate)) = fetch_from_beeminder(uid, beem, &conn).await {
                     if cur == 0 && tom == 0 && n7 == 0 { sb = 999; risk = "SAFE".to_string(); }
-                    conn.execute("UPDATE language_stats SET safebuf = $1, derail_risk = $2, daily_rate = $3::FLOAT8::NUMERIC WHERE user_id = $4 AND language_name = $5", &[ParameterValue::Int32(sb), ParameterValue::Str(risk), ParameterValue::Floating64(rate), ParameterValue::Str(uid.to_string()), ParameterValue::Str(lang.to_uppercase())])?;
+                    conn.execute("UPDATE language_stats SET safebuf = $1, derail_risk = $2, daily_rate = $3::FLOAT8::NUMERIC WHERE user_id = $4 AND language_name = $5", &[ParameterValue::Int32(sb), ParameterValue::Str(risk), ParameterValue::Floating64(rate), ParameterValue::Str(uid.to_string()), ParameterValue::Str(lang.to_uppercase())]).await?;
                 }
             }
         }
@@ -490,12 +445,12 @@ async fn run_clozemaster_scraper(db: &str, uid: &str) -> anyhow::Result<()> {
 }
 
 async fn fetch_from_beeminder(uid: &str, slug: &str, conn: &Connection) -> anyhow::Result<(i32, String, f64)> {
-     let rs = conn.query("SELECT beeminder_token_encrypted, beeminder_user_encrypted FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.to_string())])?;
-    if rs.rows.is_empty() { return Err(anyhow::anyhow!("User")); }
-    let tok = decrypt_token(&db_to_str(&rs.rows[0][0])).await?;
-    let user = if let DbValue::Str(s) = &rs.rows[0][1] { if !s.is_empty() { decrypt_token(s).await? } else { "me".to_string() } } else { "me".to_string() };
-    let res: Response = spin_sdk::http::send::<_, Response>(Request::builder().method(Method::Get).uri(format!("https://www.beeminder.com/api/v1/users/{}/goals/{}.json?auth_token={}", user, slug, tok)).build()).await?;
-    let data: serde_json::Value = serde_json::from_str(&String::from_utf8(res.body().to_vec())?)?;
+    let rs = conn.query("SELECT beeminder_token_encrypted, beeminder_user_encrypted FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.to_string())]).await?.collect().await?;
+    if rs.is_empty() { return Err(anyhow::anyhow!("User")); }
+    let tok = decrypt_token(match &rs[0][0] { DbValue::Str(s) => s, _ => "" }).await?;
+    let user = if let DbValue::Str(s) = &rs[0][1] { if !s.is_empty() { decrypt_token(s).await? } else { "me".to_string() } } else { "me".to_string() };
+    let res = spin_sdk::http::send(Request::builder().method(Method::GET).uri(format!("https://www.beeminder.com/api/v1/users/{}/goals/{}.json?auth_token={}", user, slug, tok)).body(String::new())?).await?;
+    let data: serde_json::Value = serde_json::from_str(&String::from_utf8(res.into_body().collect().await.map_err(|_| anyhow::anyhow!("body"))?.to_bytes().to_vec())?)?;
     let sb = data.get("safebuf").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
     let rate = data.get("rate").and_then(|v| v.as_f64()).unwrap_or(0.0);
     let risk = if sb <= 0 { "CRITICAL" } else if sb == 1 { "WARNING" } else if sb <= 3 { "CAUTION" } else { "SAFE" };
@@ -503,22 +458,34 @@ async fn fetch_from_beeminder(uid: &str, slug: &str, conn: &Connection) -> anyho
 }
 
 async fn push_to_beeminder_idempotent(uid: &str, slug: &str, val: f64, comment: &str, rid: &str, conn: &Connection) -> anyhow::Result<()> {
-     let rs = conn.query("SELECT beeminder_token_encrypted, beeminder_user_encrypted FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.to_string())])?;
-    if rs.rows.is_empty() { return Err(anyhow::anyhow!("User")); }
-    let tok = decrypt_token(&db_to_str(&rs.rows[0][0])).await?;
-    let user = if let DbValue::Str(s) = &rs.rows[0][1] { if !s.is_empty() { decrypt_token(s).await? } else { "me".to_string() } } else { "me".to_string() };
+    let rs = conn.query("SELECT beeminder_token_encrypted, beeminder_user_encrypted FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.to_string())]).await?.collect().await?;
+    if rs.is_empty() { return Err(anyhow::anyhow!("User")); }
+    let tok = decrypt_token(match &rs[0][0] { DbValue::Str(s) => s, _ => "" }).await?;
+    let user = if let DbValue::Str(s) = &rs[0][1] { if !s.is_empty() { decrypt_token(s).await? } else { "me".to_string() } } else { "me".to_string() };
     let body = format!("auth_token={}&value={}&comment={}&requestid={}", tok, val, urlencoding::encode(comment), urlencoding::encode(rid));
-    let res: Response = spin_sdk::http::send::<_, Response>(Request::builder().method(Method::Post).uri(format!("https://www.beeminder.com/api/v1/users/{}/goals/{}/datapoints.json", user, slug)).header("content-type", "application/x-www-form-urlencoded").body(body.into_bytes()).build()).await?;
-    if *res.status() == 422 { return Ok(()); }
-    if !(200..300).contains(res.status()) { return Err(anyhow::anyhow!("Push fail: {}", res.status())); }
+    let res = spin_sdk::http::send(Request::builder().method(Method::POST).uri(format!("https://www.beeminder.com/api/v1/users/{}/goals/{}/datapoints.json", user, slug)).header("content-type", "application/x-www-form-urlencoded").body(body)?).await?;
+    if res.status().as_u16() == 422 { return Ok(()); }
+    if !(200..300).contains(&res.status().as_u16()) { return Err(anyhow::anyhow!("Push fail: {}", res.status())); }
+    Ok(())
+}
+
+#[allow(dead_code)]
+async fn push_to_beeminder(uid: &str, slug: &str, val: f64, comment: &str, conn: &Connection) -> anyhow::Result<()> {
+    let rs = conn.query("SELECT beeminder_token_encrypted, beeminder_user_encrypted FROM users WHERE pocket_id_sub = $1", &[ParameterValue::Str(uid.to_string())]).await?.collect().await?;
+    if rs.is_empty() { return Err(anyhow::anyhow!("User")); }
+    let tok = decrypt_token(match &rs[0][0] { DbValue::Str(s) => s, _ => "" }).await?;
+    let user = if let DbValue::Str(s) = &rs[0][1] { if !s.is_empty() { decrypt_token(s).await? } else { "me".to_string() } } else { "me".to_string() };
+    let body = format!("auth_token={}&value={}&comment={}", tok, val, urlencoding::encode(comment));
+    let res = spin_sdk::http::send(Request::builder().method(Method::POST).uri(format!("https://www.beeminder.com/api/v1/users/{}/goals/{}/datapoints.json", user, slug)).header("content-type", "application/x-www-form-urlencoded").body(body)?).await?;
+    if !(200..300).contains(&res.status().as_u16()) { return Err(anyhow::anyhow!("Push: {}", res.status())); }
     Ok(())
 }
 
 async fn send_twilio_sms(sid: &str, tok: &str, from: &str, to: &str, msg: &str) -> anyhow::Result<()> {
     let auth = base64::engine::general_purpose::STANDARD.encode(format!("{}:{}", sid, tok));
     let body = format!("From={}&To={}&Body={}", urlencoding::encode(from), urlencoding::encode(to), urlencoding::encode(msg));
-    let res: Response = spin_sdk::http::send::<_, Response>(Request::builder().method(Method::Post).uri(format!("https://api.twilio.com/2010-04-01/Accounts/{}/Messages.json", sid)).header("Authorization", &format!("Basic {}", auth)).header("Content-Type", "application/x-www-form-urlencoded").body(body.into_bytes()).build()).await?;
-    if !(200..300).contains(res.status()) { return Err(anyhow::anyhow!("Twilio: {}", res.status())); }
+    let res = spin_sdk::http::send(Request::builder().method(Method::POST).uri(format!("https://api.twilio.com/2010-04-01/Accounts/{}/Messages.json", sid)).header("Authorization", &format!("Basic {}", auth)).header("Content-Type", "application/x-www-form-urlencoded").body(body)?).await?;
+    if !(200..300).contains(&res.status().as_u16()) { return Err(anyhow::anyhow!("Twilio: {}", res.status())); }
     Ok(())
 }
 
@@ -527,42 +494,38 @@ fn aggregate_step_count(rs: &Vec<spin_sdk::pg::Row>) -> i32 { rs.iter().filter_m
 fn should_dispatch(h: u32, s: i32, m: Option<u64>, _p: &NotificationPrefs) -> bool { if h < 9 || h >= 21 || s >= 2000 { false } else { m.map_or(true, |v| v >= 120) } }
 
 async fn decrypt_token(enc_hex: &str) -> anyhow::Result<String> {
-    let key_str = variables::get("master_encryption_key")?;
+    let key_str = variables::get("master_encryption_key").await?;
     let key_bytes = hex::decode(key_str.trim())?;
-    let cipher = Aes256Gcm::new_from_slice(&key_bytes).map_err(|_| anyhow::anyhow!("cipher"))?;
+    let cipher = Aes256Gcm::new_from_slice(&key_bytes)?;
     let enc_bytes = hex::decode(enc_hex.trim())?;
     if enc_bytes.len() < 12 { return Err(anyhow::anyhow!("Short")); }
-    let nonce = Nonce::from_slice(&enc_bytes[..12]);
-    let ct = &enc_bytes[12..];
-    let dec = cipher.decrypt(nonce, ct).map_err(|_| anyhow::anyhow!("Dec fail"))?;
+    let (nonce, ct) = enc_bytes.split_at(12);
+    let dec = cipher.decrypt(Nonce::from_slice(nonce), ct).map_err(|_| anyhow::anyhow!("Dec fail"))?;
     Ok(String::from_utf8(dec)?)
 }
 
 async fn encrypt_token(plain: &str) -> anyhow::Result<String> {
-    let key_str = variables::get("master_encryption_key")?;
+    let key_str = variables::get("master_encryption_key").await?;
     let key_bytes = hex::decode(key_str.trim())?;
-    let cipher = Aes256Gcm::new_from_slice(&key_bytes).map_err(|_| anyhow::anyhow!("cipher"))?;
-    let mut nonce_bytes = [0u8; 12]; getrandom::getrandom(&mut nonce_bytes).map_err(|_| anyhow::anyhow!("rand"))?;
-    let nonce = Nonce::from_slice(&nonce_bytes);
-    let ct = cipher.encrypt(nonce, plain.as_bytes()).map_err(|_| anyhow::anyhow!("Enc fail"))?;
-    let mut comb = nonce_bytes.to_vec(); comb.extend_from_slice(&ct);
+    let cipher = Aes256Gcm::new_from_slice(&key_bytes)?;
+    let mut nonce = [0u8; 12]; getrandom::getrandom(&mut nonce).map_err(|_| anyhow::anyhow!("rand"))?;
+    let ct = cipher.encrypt(Nonce::from_slice(&nonce), plain.as_bytes()).map_err(|_| anyhow::anyhow!("Enc fail"))?;
+    let mut comb = nonce.to_vec(); comb.extend_from_slice(&ct);
     Ok(hex::encode(comb))
 }
 
-async fn extract_user_id(auth: Option<&str>) -> Option<String> {
-    if let Ok(bypass) = variables::get("auth_bypass") {
+async fn extract_user_id(auth: Option<&spin_sdk::http::HeaderValue>) -> Option<String> {
+    let val = std::str::from_utf8(auth?.as_ref()).ok()?;
+    if let Ok(bypass) = variables::get("auth_bypass").await {
         if bypass == "true" {
-            if let Some(h) = auth {
-                let token = h.strip_prefix("Bearer ").unwrap_or(h);
-                if token.starts_with("TestUser ") {
-                    return Some(token[9..].to_string());
-                }
+            let token = val.strip_prefix("Bearer ").unwrap_or(val);
+            if token.starts_with("TestUser ") {
+                return Some(token[9..].to_string());
             }
         }
     }
-    let val = auth?;
     if !val.starts_with("Bearer ") { return None; }
-    let tok = &val[7..]; let manual = variables::get("oidc_jwks_json").ok()?;
+    let tok = &val[7..]; let manual = variables::get("oidc_jwks_json").await.ok()?;
     let jwks: Jwks = serde_json::from_str(&manual).ok()?;
     let parts: Vec<&str> = tok.split('.').collect();
     if parts.len() != 3 { return None; }
@@ -584,17 +547,18 @@ async fn extract_user_id(auth: Option<&str>) -> Option<String> {
     } else { None }
 }
 
-async fn register_cloud_heartbeat(conn: &Connection, uid: &str) {
-    let prov = variables::get("cloud_provider").unwrap_or_else(|_| "unknown".to_string());
+async fn register_cloud_heartbeat(conn: &Connection, uid: &str) -> anyhow::Result<()> {
+    let prov = variables::get("cloud_provider").await.unwrap_or_else(|_| "unknown".to_string());
     let role = match prov.as_str() { "akamai" => "akamai_functions", "fermyon" => "fermyon_cloud", _ => "unknown" };
-    let _ = conn.execute("INSERT INTO scheduler_election (user_id, role, process_id, heartbeat) VALUES ($1, $2, $3, CURRENT_TIMESTAMP) ON CONFLICT (user_id, role) DO UPDATE SET heartbeat = EXCLUDED.heartbeat, process_id = EXCLUDED.process_id", &[ParameterValue::Str(uid.to_string()), ParameterValue::Str(role.to_string()), ParameterValue::Str(prov)]);
+    conn.execute("INSERT INTO scheduler_election (user_id, role, process_id, heartbeat) VALUES ($1, $2, $3, CURRENT_TIMESTAMP) ON CONFLICT (user_id, role) DO UPDATE SET heartbeat = EXCLUDED.heartbeat, process_id = EXCLUDED.process_id", &[ParameterValue::Str(uid.to_string()), ParameterValue::Str(role.to_string()), ParameterValue::Str(prov)]).await?;
+    Ok(())
 }
 
 fn get_modality_status(role: &str, mins: u64) -> &'static str {
     match role { "leader" => if mins < 2 { "healthy" } else if mins < 5 { "degraded" } else { "offline" }, "android_client" => if mins < 20 { "healthy" } else if mins < 60 { "degraded" } else { "offline" }, "akamai_functions" => if mins < 135 { "healthy" } else if mins < 250 { "degraded" } else { "offline" }, "fermyon_cloud" => if mins < 5 { "healthy" } else if mins < 15 { "degraded" } else { "offline" }, _ => "unknown" }
 }
 
-async fn handle_weather_heuristic_get(_r: Request) -> anyhow::Result<Response> {
+async fn handle_weather_heuristic_get(_r: Request) -> anyhow::Result<Response<String>> {
     #[derive(Serialize)] struct WeatherResp { is_walk_appropriate: bool, conditions: String, description: String, temperature: f64, sunrise: i64, sunset: i64, is_dark: bool, now_epoch: i64, data_ts: i64, recommendation: String }
     json_response(200, &WeatherResp {
         is_walk_appropriate: true,
@@ -609,7 +573,6 @@ async fn handle_weather_heuristic_get(_r: Request) -> anyhow::Result<Response> {
         recommendation: "Great day for a walk!".to_string()
     })
 }
-
 #[derive(Serialize)] struct StatusResponse { status: String, message: String }
 #[derive(Deserialize, Serialize, Debug)] struct Jwks { keys: Vec<JwKey> }
 #[derive(Deserialize, Serialize, Debug)] struct JwKey { kid: String, kty: String, alg: String, n: String, e: String }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mecris"
-version = "0.0.1-beta.10"
+version = "0.0.1-rc.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/audit_groqspend.py
+++ b/scripts/audit_groqspend.py
@@ -1,0 +1,87 @@
+import asyncio
+import os
+import sys
+from datetime import datetime
+from dotenv import load_dotenv
+
+# Add project root to python path to load local modules
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from beeminder_client import BeeminderClient
+
+async def main():
+    load_dotenv()
+    
+    # Use the familiar user ID mapped from local configuration
+    client = BeeminderClient(user_id="c0a81a4b-115a-4eb6-bc2c-40908c58bf64")
+    goal_slug = "groqspend"
+    
+    print("=== STARTING BEEMINDER AUDIT & CLEANUP FOR GROQSPEND ===")
+    
+    # 1. Delete bad backdated datapoints
+    bad_datapoints = [
+        {"id": "6a43bda3d4865fd5eb2939be", "desc": "0.86 June final backdated to 20260531"},
+        {"id": "6a2a1890d4865fb51835d9d3", "desc": "0.35 June mid-month backdated to 20260531"},
+        {"id": "6a2a1890d4865fb50435dc6d", "desc": "0.20 May spend backdated to 20260430"}
+    ]
+    
+    for dp in bad_datapoints:
+        print(f"Deleting datapoint {dp['id']} ({dp['desc']})...")
+        success = await client.delete_datapoint(goal_slug, dp['id'])
+        print(f"Result: {'SUCCESS' if success else 'FAILED'}")
+        
+    # 2. Add June final spend on the correct daystamp (20260630)
+    print("\nRecording June final spend on the correct date (20260630)...")
+    success = await client.add_datapoint(
+        goal_slug=goal_slug,
+        value=0.86,
+        comment="Month-end reading: $0.50 (account spend) + $0.36 (API spend)",
+        daystamp="20260630"
+    )
+    print(f"Result: {'SUCCESS' if success else 'FAILED'}")
+    
+    # 3. Retrieve final history to produce audit report
+    print("\nFetching updated datapoints for final audit...")
+    datapoints = await client.get_goal_datapoints(goal_slug, count=40)
+    
+    # Organize data by month
+    monthly_data = {}
+    for dp in datapoints:
+        daystamp = dp.get("daystamp")
+        if not daystamp or len(daystamp) != 8:
+            continue
+        year = daystamp[0:4]
+        month = daystamp[4:6]
+        day = daystamp[6:8]
+        month_key = f"{year}-{month}"
+        
+        if month_key not in monthly_data:
+            monthly_data[month_key] = []
+        monthly_data[month_key].append({
+            "day": day,
+            "value": float(dp.get("value", 0.0)),
+            "comment": dp.get("comment", "")
+        })
+        
+    print("\n=== GROQSPEND AUDIT REPORT ===")
+    print(f"{'Month':<10} | {'Days Traced':<12} | {'Max Spend':<10} | {'Status':<15}")
+    print("-" * 57)
+    
+    for month_key in sorted(monthly_data.keys(), reverse=True):
+        readings = monthly_data[month_key]
+        if not readings:
+            continue
+        max_spend = max(r["value"] for r in readings)
+        days_traced = len(set(r["day"] for r in readings))
+        status = "PASSED (< $1.00)" if max_spend < 1.00 else "EXCEEDED LIMIT"
+        print(f"{month_key:<10} | {days_traced:<12} | ${max_spend:<9.2f} | {status:<15}")
+        
+    print("\nDetailed Datapoints:")
+    for month_key in sorted(monthly_data.keys(), reverse=True):
+        print(f"\nMonth: {month_key}")
+        for r in sorted(monthly_data[month_key], key=lambda x: x["day"]):
+            print(f"  Day {r['day']}: ${r['value']:.2f} - {r['comment']}")
+            
+    await client.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/correct_may_spend.py
+++ b/scripts/correct_may_spend.py
@@ -1,0 +1,41 @@
+import asyncio
+import os
+import sys
+from dotenv import load_dotenv
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from beeminder_client import BeeminderClient
+
+async def main():
+    load_dotenv()
+    client = BeeminderClient(user_id="c0a81a4b-115a-4eb6-bc2c-40908c58bf64")
+    goal_slug = "groqspend"
+    
+    print("=== CORRECTING MAY 31st DATAPOINT ===")
+    
+    # Delete the old 0.57 datapoint on May 31st
+    old_id = "6a1c9482f0168a73d9b45619"
+    print(f"Deleting old May 31st datapoint {old_id} (value 0.57)...")
+    del_success = await client.delete_datapoint(goal_slug, old_id)
+    print(f"Result: {'SUCCESS' if del_success else 'FAILED'}")
+    
+    # Add the correct 0.87 datapoint on May 31st
+    print("\nAdding correct May 31st datapoint (value 0.87: $0.37 + $0.50)...")
+    add_success = await client.add_datapoint(
+        goal_slug=goal_slug,
+        value=0.87,
+        comment="Final value for May: $0.37 (account spend) + $0.50 (API spend)",
+        daystamp="20260531"
+    )
+    print(f"Result: {'SUCCESS' if add_success else 'FAILED'}")
+    
+    # Fetch and verify history
+    print("\nFetching updated history to verify...")
+    datapoints = await client.get_goal_datapoints(goal_slug, count=10)
+    for dp in datapoints:
+        print(f"ID: {dp.get('id')}, Date: {dp.get('daystamp')}, Value: {dp.get('value')}, Comment: {dp.get('comment')}")
+        
+    await client.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_beta9_e2e.py
+++ b/tests/test_beta9_e2e.py
@@ -10,6 +10,11 @@ BASE_URL = "http://127.0.0.1:3000"
 TEST_USER_ID = "c0a81a4b-115a-4eb6-bc2c-40908c58bf64"
 AUTH_HEADER = {"Authorization": f"Bearer TestUser {TEST_USER_ID}"}
 
+@pytest.fixture(autouse=True)
+def disable_mock_requests(monkeypatch):
+    """Restore real requests for E2E tests."""
+    monkeypatch.undo()
+
 def test_languages_dto_completeness():
     """Verify that /languages returns all fields required by the Android app."""
     resp = requests.get(f"{BASE_URL}/languages", headers=AUTH_HEADER)

--- a/tests/test_beta9_regressions.py
+++ b/tests/test_beta9_regressions.py
@@ -58,7 +58,8 @@ def test_greek_mapping_safety():
 
 def test_cloud_sync_routing():
     """Verify that /internal/cloud-sync is correctly routed and returns success."""
-    resp = requests.post(f"{BASE_URL}/internal/cloud-sync", headers=AUTH_HEADER)
+    fake_header = {"Authorization": "Bearer TestUser fake-user-without-creds"}
+    resp = requests.post(f"{BASE_URL}/internal/cloud-sync", headers=fake_header)
     # This should return 200/success even if scraper fails internally, but routing must work
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/test_cloud_beta4_validation.py
+++ b/tests/test_cloud_beta4_validation.py
@@ -9,7 +9,7 @@ AKAMAI_URL = "https://394b84e7-760c-4336-975b-653c17fdb446.fwf.app"
 
 @pytest.mark.asyncio
 async def test_fermyon_review_pump_not_implemented():
-    """Verify Fermyon Cloud returns NotImplementedError for SDK v4 binaries."""
+    """Verify Fermyon Cloud returns NotImplementedError or 404 (disabled) for SDK v4 binaries."""
     async with httpx.AsyncClient() as client:
         url = f"{FERMYON_URL}/internal/review-pump-status-py"
         try:
@@ -18,9 +18,10 @@ async def test_fermyon_review_pump_not_implemented():
                 json={"debt": 0, "tomorrow_liability": 0, "daily_completions": 0, "multiplier_x10": 10},
                 timeout=10.0
             )
-            # We expect a 500 for NotImplementedError or similar
-            assert resp.status_code == 500
-            assert "NotImplementedError" in resp.text
+            # We expect a 500 for NotImplementedError or 404 if the route is fully disabled
+            assert resp.status_code in [404, 500]
+            if resp.status_code == 500:
+                assert "NotImplementedError" in resp.text
             print(f"\n[Verified] Fermyon Review Pump: {resp.status_code} - {resp.text[:50]}...")
         except Exception as e:
             pytest.fail(f"Fermyon request failed: {e}")
@@ -44,7 +45,11 @@ async def test_local_health_200():
     try:
         async with httpx.AsyncClient() as client:
             url = f"{LOCAL_URL}/health"
-            resp = await client.get(url, timeout=2.0)
+            resp = await client.get(
+                url, 
+                headers={"Authorization": "Bearer TestUser c0a81a4b-115a-4eb6-bc2c-40908c58bf64"}, 
+                timeout=2.0
+            )
             assert resp.status_code == 200
             print(f"\n[Verified] Local Health: {resp.status_code}")
     except (httpx.ConnectError, httpx.TimeoutException):

--- a/tests/test_cloud_sync.py
+++ b/tests/test_cloud_sync.py
@@ -1,10 +1,10 @@
 """
-Tests for the async /internal/cloud-sync endpoint (yebyen/mecris#133).
+Tests for the synchronous /internal/cloud-sync endpoint.
 
-Covers behavioral changes introduced in commit 66396ee:
-- Endpoint returns {"status": "accepted", ...} immediately (202 fire-and-forget)
-- sync_all is called via asyncio.create_task (not awaited in the handler body)
-- Exceptions in the background task are swallowed and do not propagate to the caller
+Covers:
+- Endpoint returns {"status": "success", ...} on success.
+- sync_all is awaited synchronously inside the handler body.
+- Exceptions in sync_all propagate as HTTP 500 exceptions.
 """
 
 import asyncio
@@ -12,6 +12,7 @@ import sys
 
 import pytest
 from unittest.mock import patch, AsyncMock
+from fastapi import HTTPException
 
 
 def _make_mcp_importable():
@@ -23,8 +24,8 @@ def _make_mcp_importable():
 
 
 @pytest.mark.asyncio
-async def test_cloud_sync_returns_accepted_status():
-    """Endpoint returns status='accepted' and a guidance message immediately."""
+async def test_cloud_sync_returns_success_status():
+    """Endpoint returns status='success' and a completion message."""
     sys.modules.pop("mcp_server", None)
 
     mock_sync = AsyncMock(return_value={"synced": 5})
@@ -36,15 +37,13 @@ async def test_cloud_sync_returns_accepted_status():
             from mcp_server import trigger_cloud_sync_endpoint
             result = await trigger_cloud_sync_endpoint(user_id="test-user")
 
-    assert result["status"] == "accepted"
-    assert "message" in result
-    # Message must guide the caller to check /languages rather than waiting on this call
-    assert "/languages" in result["message"] or "moments" in result["message"]
+    assert result["status"] == "success"
+    assert result["message"] == "Cloud sync complete"
 
 
 @pytest.mark.asyncio
-async def test_cloud_sync_sync_all_called_via_background_task():
-    """sync_all is not called until the event loop yields (fire-and-forget semantics)."""
+async def test_cloud_sync_sync_all_called_synchronously():
+    """sync_all is called and awaited synchronously during the request."""
     sys.modules.pop("mcp_server", None)
 
     mock_sync = AsyncMock(return_value={"synced": 3})
@@ -57,20 +56,14 @@ async def test_cloud_sync_sync_all_called_via_background_task():
 
             result = await trigger_cloud_sync_endpoint(user_id="test-user")
 
-            # Endpoint returns immediately — sync_all has not been awaited yet
-            assert result["status"] == "accepted"
-            mock_service.sync_all.assert_not_awaited()
-
-            # Yield to the event loop so the background task can run
-            await asyncio.sleep(0)
-
-            # sync_all now called exactly once with the correct user_id
+            assert result["status"] == "success"
+            # sync_all has already been awaited when trigger_cloud_sync_endpoint returns
             mock_service.sync_all.assert_awaited_once_with(user_id="test-user")
 
 
 @pytest.mark.asyncio
-async def test_cloud_sync_exception_in_background_does_not_propagate():
-    """Exception raised by sync_all is swallowed; endpoint response is unaffected."""
+async def test_cloud_sync_exception_propagates_as_http_500():
+    """Exception raised by sync_all propagates as HTTPException with 500 status."""
     sys.modules.pop("mcp_server", None)
 
     mock_sync = AsyncMock(side_effect=RuntimeError("Clozemaster scraper down"))
@@ -81,12 +74,11 @@ async def test_cloud_sync_exception_in_background_does_not_propagate():
             mock_service.sync_all = mock_sync
             from mcp_server import trigger_cloud_sync_endpoint
 
-            # Must not raise even though sync_all will fail
-            result = await trigger_cloud_sync_endpoint(user_id="test-user")
-            assert result["status"] == "accepted"
+            # Exception must propagate as HTTP 500
+            with pytest.raises(HTTPException) as exc_info:
+                await trigger_cloud_sync_endpoint(user_id="test-user")
+            
+            assert exc_info.value.status_code == 500
+            assert "Clozemaster scraper down" in exc_info.value.detail
 
-            # Let the background task run — exception must not propagate out
-            await asyncio.sleep(0)
-
-    # Reaching here without an unhandled exception confirms isolation
     mock_service.sync_all.assert_awaited_once()

--- a/tests/test_daily_aggregate_status.py
+++ b/tests/test_daily_aggregate_status.py
@@ -26,8 +26,8 @@ def _base_patches():
 
 def _make_lang_stats(arabic_goal_met: bool, greek_goal_met: bool):
     return {
-        "arabic": {"goal_met": arabic_goal_met, "status": "laminar", "target_flow_rate": 0, "current_flow_rate": 5},
-        "greek": {"goal_met": greek_goal_met, "status": "laminar", "target_flow_rate": 0, "current_flow_rate": 10},
+        "arabic": {"goal_met": arabic_goal_met, "status": "laminar", "target_flow_rate": 0 if arabic_goal_met else 5, "current_flow_rate": 5},
+        "greek": {"goal_met": greek_goal_met, "status": "laminar", "target_flow_rate": 0 if greek_goal_met else 10, "current_flow_rate": 10},
     }
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -196,6 +196,21 @@ async def test_languages_sorted_beeminder_tracked_first():
         assert not (seen_false and flag), f"has_goal=True appeared after has_goal=False in: {names}"
 
 
+@pytest.mark.asyncio
+async def test_languages_error_handling():
+    """`get_languages` raises HTTPException with 503 when velocity stats returns an error."""
+    sys.modules.pop("mcp_server", None)
+
+    env_patch, db_patch = _make_mcp_importable()
+    with env_patch, db_patch:
+        with patch("mcp_server.get_language_velocity_stats", return_value={"error": "Database loading"}):
+            from mcp_server import get_languages, HTTPException
+            with pytest.raises(HTTPException) as exc_info:
+                await get_languages(user_id="test-user")
+            assert exc_info.value.status_code == 503
+            assert exc_info.value.detail == "Database loading"
+
+
 # ---------------------------------------------------------------------------
 # get_daily_aggregate_status — Majesty Cake backend (kingdonb/mecris#170)
 # ---------------------------------------------------------------------------

--- a/usage_tracker.py
+++ b/usage_tracker.py
@@ -30,9 +30,9 @@ class UsageTracker:
     def __init__(self, user_id: str = None):
         self.neon_url = os.getenv("NEON_DB_URL")
         self.user_id = credentials_manager.resolve_user_id(user_id)
-        self.use_neon = False
+        self._use_neon = False
+        self._db_initialized = False
         self.encryption = EncryptionService()
-        self.init_database()
         
         # Current pricing (as of 2025) - Claude 3.5 Sonnet
         # Input: $3/million tokens, Output: $15/million tokens
@@ -47,13 +47,30 @@ class UsageTracker:
             }
         }
     
+    @property
+    def use_neon(self) -> bool:
+        if not self._db_initialized:
+            self.ensure_db_initialized()
+        return self._use_neon
+
+    @use_neon.setter
+    def use_neon(self, value: bool):
+        self._use_neon = value
+        if value:
+            self._db_initialized = True
+
+    def ensure_db_initialized(self):
+        if not self._db_initialized:
+            self._db_initialized = True
+            self.init_database()
+
     def init_database(self):
         """Initialize database for usage tracking."""
         if self.neon_url:
             try:
                 import psycopg2
                 self._init_neon()
-                self.use_neon = True
+                self._use_neon = True
                 logger.info("UsageTracker: Neon database initialized successfully.")
                 return
             except Exception as e:

--- a/virtual_budget_manager.py
+++ b/virtual_budget_manager.py
@@ -66,7 +66,11 @@ class VirtualBudgetManager:
             }
         }
         
-        if self.neon_url:
+        self._db_initialized = False
+
+    def ensure_db_initialized(self):
+        if not self._db_initialized and self.neon_url:
+            self._db_initialized = True
             self.init_database()
 
     def init_database(self):
@@ -133,6 +137,7 @@ class VirtualBudgetManager:
             logger.error(f"Neon DB init failed: {e}")
 
     def _ensure_daily_budget(self, user_id: str = None):
+        self.ensure_db_initialized()
         target_user_id = user_id or self.user_id
         if not self.neon_url or not target_user_id: return
         today = date.today()
@@ -241,6 +246,7 @@ class VirtualBudgetManager:
             return {"error": str(e)}
 
     def reset_daily_budget(self, user_id: str = None) -> Dict:
+        self.ensure_db_initialized()
         target_user_id = user_id or self.user_id
         if not self.neon_url: return {"error": "Neon DB not configured"}
         today, now = date.today(), datetime.now()
@@ -255,6 +261,7 @@ class VirtualBudgetManager:
             return {"error": str(e)}
 
     def get_usage_summary(self, days: int = 7, user_id: str = None) -> Dict:
+        self.ensure_db_initialized()
         target_user_id = user_id or self.user_id
         if not self.neon_url: return {"error": "Neon DB not configured"}
         cutoff = (datetime.now() - timedelta(days=days)).isoformat()

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.0.1-beta.10",
+  "version": "0.0.1-rc.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Overview

This release candidate transitioning the suite out of beta (`0.0.1-rc.1` / versionCode `26`) resolves key reliability issues across the local/cloud Spin service and Python backend.

### Key Changes

#### 1. Spin SDK 6.0.0 Migration & Query Deadlock Resolution (`feat`)
- **Asynchronous DB Stack**: Upgraded `sync-service` from Spin SDK v5 to **Spin SDK 6.0.0**. Moving the Postgres query operations to async futures (`Connection::open().await?` and stream collection via `.await?.collect().await?`) prevents blocking the single-threaded WASM runtime and **completely resolves the database query hangs** encountered on local endpoints.
- **DTO and Path Parsing Alignments**:
  - Restored mock weather responses to `/internal/weather-heuristic`.
  - Added new DTO fields `has_goal`, `target_flow_rate`, and `outstanding_debt` to `/languages`.
  - Fixed path routing for wildcard matches and full URLs.
  - Implemented safe database value conversion helpers (`db_to_i32`, `db_to_f64`, etc.).

#### 2. Python Backend & Audit Robustness (`chore`)
- **Lazy Database Initialization**: Replaced active/synchronous database connection setups in `UsageTracker` and `VirtualBudgetManager`'s constructor with lazy initialization (`ensure_db_initialized()`), preventing import-time database connection blocks and system startup hangs.
- **Improved Error Statuses**: Aligned MCP server reload logic to throw clean `HTTP 503 Service Unavailable` exceptions when language stats fail to load, instead of default 500 server errors.
- **Audit Tools & Beeminder client DELETE**: Added `DELETE` method support to `BeeminderClient` for managing datapoints, and fixed historical month-end timestamp offsets in the Groq spending tracker.

#### 3. Suite-Wide Version Bump (`release`)
- Incremented package configurations, spin manifests, and dependency specifications across Android (`versionCode = 26`), Spin services, Python server, and Web assets to `0.0.1-rc.1`.
