### PR TITLE
fix(android): restore Gradle JVM and Kotlin daemon memory args to prevent OOM

### DIFF
--- a/mecris-go-project/gradle.properties
+++ b/mecris-go-project/gradle.properties
@@ -3,3 +3,5 @@ android.newDsl=false
 kapt.use.worker.api=false
 kapt.verbose=true
 kapt.incremental.apt=false
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:+UseG1GC
+kotlin.daemon.jvmopts=-Xmx1024m


### PR DESCRIPTION
This PR restores the `org.gradle.jvmargs` and `kotlin.daemon.jvmopts` configurations to `gradle.properties` which were accidentally removed in 9a351c8e (the KAPT to KSP migration). Without these parameters, the JVM running `assembleRelease` runs out of memory on GitHub Actions runners because the R8 obfuscation/minimization tool is highly memory intensive. Adding these limits prevents the JVM from exceeding Action runner resources and crashing. Verified locally: `assembleRelease` now completes successfully in ~1m 12s.