### PR TITLE
fix(auth): calm AppAuth network reconnects & add chore-pocketid-inventory skill

### DIFF
--- a/.claude/skills/chore-pocketid-inventory/SKILL.md
+++ b/.claude/skills/chore-pocketid-inventory/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: chore-pocketid-inventory
+description: 'Weekend chore 5-minute survey and verification for PocketID OIDC server on Synology, DNS/LAN perimeter reachability, JWKS discovery, and AppAuth token exchange health. Trigger with /chore-pocketid-inventory'
+allowed-tools: ['run_command', 'view_file', 'grep_search', 'list_dir', 'call_mcp_tool']
+---
+
+# Weekend Chore: PocketID OIDC Server Inventory
+
+Part of the **Weekend Chores** accountability workflow. This skill guides the **human operator** and AI assistant through a 5-minute inspection of the **PocketID** OpenID Connect authentication service running locally on the home Synology NAS (`https://metnoom.urmanac.com`), ensuring passkey validation, client ID bindings, and OIDC discovery endpoints are healthy.
+
+## The PocketID Architecture & Authentication Boundary
+
+PocketID serves as the primary **Neural Link** identity provider across the Mecris ecosystem:
+- **Server Instance**: Containerized PocketID instance running on the local Synology NAS.
+- **LAN IP & Perimeter**: `10.17.13.140` / `https://metnoom.urmanac.com`.
+- **Client Application ID**: `21f65a91-c4df-468d-a256-3b66a54c6d5f` (Mecris Go Android client).
+- **Redirect URI**: `com.mecris.go:/oauth2redirect`.
+- **Token Lifecycle**:
+  - 30-day sliding window refresh token TTL.
+  - Proactive background refresh at 80% of TTL.
+  - Hardware-backed encrypted credential storage via `EncryptedSharedPreferences` / Android MasterKey.
+
+---
+
+## 5-Minute Guided Chore Routine
+
+### Step 1: Verify LAN Reachability & DNS Resolution
+```bash
+# Ping the local Synology PocketID host
+ping -c 3 metnoom.urmanac.com
+```
+- Confirms local DNS resolves `metnoom.urmanac.com` to the internal LAN IP (`10.17.13.140`) without routing drops.
+
+### Step 2: Query OIDC Discovery Endpoints
+```bash
+# Query openid-configuration from PocketID
+curl -s https://metnoom.urmanac.com/.well-known/openid-configuration | python3 -m json.tool
+```
+- Verifies HTTP 200 response and confirms valid endpoints:
+  - `authorization_endpoint`: `https://metnoom.urmanac.com/authorize`
+  - `token_endpoint`: `https://metnoom.urmanac.com/api/oidc/token`
+  - `jwks_uri`: `https://metnoom.urmanac.com/.well-known/jwks.json`
+
+### Step 3: Verify JWKS Public Key Certificates
+```bash
+# Inspect active public signing keys
+curl -s https://metnoom.urmanac.com/.well-known/jwks.json | python3 -m json.tool
+```
+- Confirms the cryptographic signing keys are active and non-empty.
+
+### Step 4: Verify Android Client AppAuth Error Classification
+```bash
+# Inspect Android PocketIdAuthRepository for structured AppAuth error handling
+view_file mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthError.kt
+```
+- Confirms `NetworkUnreachable` vs. `TokenRevoked` classifications differentiate transient network hops from true session expiry.
+
+### Step 5: Human Visual Confirmation (The Chore)
+1. Open the **PocketID Admin Console** in your browser (`https://metnoom.urmanac.com`).
+2. Confirm user accounts, active passkeys, and client applications are listed with green status.
+3. Check your phone to ensure the Mecris Go dashboard shows a calm, connected state.

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: release-workflow
+description: 'Standard procedure for creating, validating, bumping, and publishing Mecris ecosystem releases following docs/RELEASE_PROCESS.md. Trigger with /release-workflow'
+allowed-tools: ['run_command', 'view_file', 'grep_search', 'list_dir', 'call_mcp_tool']
+---
+
+# Release Workflow: Mecris Ecosystem Release Procedure
+
+Guides the AI assistant and operator through the standardized release procedure defined in [`docs/RELEASE_PROCESS.md`](file:///Users/yebyen/w/mecris/docs/RELEASE_PROCESS.md).
+
+## Critical Version Tagging Convention
+
+> **All release tags MUST use the `v` prefix:** `v0.0.1-rc.5`, `v0.0.1-beta.10`, `v0.0.1`, etc.
+
+The GitHub Actions Release workflow triggers exclusively on tags matching `v*` and `0.*`. Always prefix with `v` to ensure consistent GitHub Release creation and tag history matching.
+
+---
+
+## 5-Step Release Execution
+
+### Step 1: Pre-Release Validation (All Tests Must Pass)
+```bash
+make test-python
+make test-rust
+```
+
+### Step 2: Create Release Branch & Bump Version
+```bash
+git checkout main && git pull origin main
+git checkout -b release/v{VERSION}
+make bump-version VERSION={VERSION} VC={VERSION_CODE}
+```
+*Note: Never manually edit version strings. `make bump-version` synchronizes 15+ references across Android, Spin, Web, Python, and manifests.*
+
+### Step 3: Commit, Push & Open Pull Request
+```bash
+git add VERSION_MANIFEST.json mecris-go-project/app/build.gradle.kts boris-fiona-walker/spin.toml mecris-go-spin/sync-service/spin.toml pyproject.toml web/package.json ROADMAP.md
+git commit -m "chore(release): bump version to {VERSION} + VC={VERSION_CODE}"
+git push origin release/v{VERSION}
+gh pr create --title "chore(release): release v{VERSION}" --body "Release preparation for v{VERSION} (VC={VERSION_CODE})." --base main
+```
+
+### Step 4: Verify CI & Merge PR to Main
+- Wait for mandatory CI checks on the PR to pass (`gh pr checks {PR_NUMBER}`).
+- Merge PR cleanly to `main` via squash or merge commit.
+
+### Step 5: Tag and Push Release on Main (Wait for Main CI First!)
+```bash
+git checkout main
+git pull origin main
+
+# Verify CI on main is 100% green before tagging:
+gh run list --branch main -L 1
+
+# Create and push the release tag with 'v' prefix:
+git tag v{VERSION}
+git push origin v{VERSION}
+```
+- GitHub Actions (`release.yml`) will build release artifacts, upload packages, and draft/publish the GitHub Release.

--- a/.github/skills/chore-pocketid-inventory/SKILL.md
+++ b/.github/skills/chore-pocketid-inventory/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: chore-pocketid-inventory
+description: 'Weekend chore 5-minute survey and verification for PocketID OIDC server on Synology, DNS/LAN perimeter reachability, JWKS discovery, and AppAuth token exchange health. Trigger with /chore-pocketid-inventory'
+allowed-tools: ['run_command', 'view_file', 'grep_search', 'list_dir', 'call_mcp_tool']
+---
+
+# Weekend Chore: PocketID OIDC Server Inventory
+
+Part of the **Weekend Chores** accountability workflow. This skill guides the **human operator** and AI assistant through a 5-minute inspection of the **PocketID** OpenID Connect authentication service running locally on the home Synology NAS (`https://metnoom.urmanac.com`), ensuring passkey validation, client ID bindings, and OIDC discovery endpoints are healthy.
+
+## The PocketID Architecture & Authentication Boundary
+
+PocketID serves as the primary **Neural Link** identity provider across the Mecris ecosystem:
+- **Server Instance**: Containerized PocketID instance running on the local Synology NAS.
+- **LAN IP & Perimeter**: `10.17.13.140` / `https://metnoom.urmanac.com`.
+- **Client Application ID**: `21f65a91-c4df-468d-a256-3b66a54c6d5f` (Mecris Go Android client).
+- **Redirect URI**: `com.mecris.go:/oauth2redirect`.
+- **Token Lifecycle**:
+  - 30-day sliding window refresh token TTL.
+  - Proactive background refresh at 80% of TTL.
+  - Hardware-backed encrypted credential storage via `EncryptedSharedPreferences` / Android MasterKey.
+
+---
+
+## 5-Minute Guided Chore Routine
+
+### Step 1: Verify LAN Reachability & DNS Resolution
+```bash
+# Ping the local Synology PocketID host
+ping -c 3 metnoom.urmanac.com
+```
+- Confirms local DNS resolves `metnoom.urmanac.com` to the internal LAN IP (`10.17.13.140`) without routing drops.
+
+### Step 2: Query OIDC Discovery Endpoints
+```bash
+# Query openid-configuration from PocketID
+curl -s https://metnoom.urmanac.com/.well-known/openid-configuration | python3 -m json.tool
+```
+- Verifies HTTP 200 response and confirms valid endpoints:
+  - `authorization_endpoint`: `https://metnoom.urmanac.com/authorize`
+  - `token_endpoint`: `https://metnoom.urmanac.com/api/oidc/token`
+  - `jwks_uri`: `https://metnoom.urmanac.com/.well-known/jwks.json`
+
+### Step 3: Verify JWKS Public Key Certificates
+```bash
+# Inspect active public signing keys
+curl -s https://metnoom.urmanac.com/.well-known/jwks.json | python3 -m json.tool
+```
+- Confirms the cryptographic signing keys are active and non-empty.
+
+### Step 4: Verify Android Client AppAuth Error Classification
+```bash
+# Inspect Android PocketIdAuthRepository for structured AppAuth error handling
+view_file mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthError.kt
+```
+- Confirms `NetworkUnreachable` vs. `TokenRevoked` classifications differentiate transient network hops from true session expiry.
+
+### Step 5: Human Visual Confirmation (The Chore)
+1. Open the **PocketID Admin Console** in your browser (`https://metnoom.urmanac.com`).
+2. Confirm user accounts, active passkeys, and client applications are listed with green status.
+3. Check your phone to ensure the Mecris Go dashboard shows a calm, connected state.

--- a/.github/skills/release-workflow/SKILL.md
+++ b/.github/skills/release-workflow/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: release-workflow
+description: 'Standard procedure for creating, validating, bumping, and publishing Mecris ecosystem releases following docs/RELEASE_PROCESS.md. Trigger with /release-workflow'
+allowed-tools: ['run_command', 'view_file', 'grep_search', 'list_dir', 'call_mcp_tool']
+---
+
+# Release Workflow: Mecris Ecosystem Release Procedure
+
+Guides the AI assistant and operator through the standardized release procedure defined in [`docs/RELEASE_PROCESS.md`](file:///Users/yebyen/w/mecris/docs/RELEASE_PROCESS.md).
+
+## Critical Version Tagging Convention
+
+> **All release tags MUST use the `v` prefix:** `v0.0.1-rc.5`, `v0.0.1-beta.10`, `v0.0.1`, etc.
+
+The GitHub Actions Release workflow triggers exclusively on tags matching `v*` and `0.*`. Always prefix with `v` to ensure consistent GitHub Release creation and tag history matching.
+
+---
+
+## 5-Step Release Execution
+
+### Step 1: Pre-Release Validation (All Tests Must Pass)
+```bash
+make test-python
+make test-rust
+```
+
+### Step 2: Create Release Branch & Bump Version
+```bash
+git checkout main && git pull origin main
+git checkout -b release/v{VERSION}
+make bump-version VERSION={VERSION} VC={VERSION_CODE}
+```
+*Note: Never manually edit version strings. `make bump-version` synchronizes 15+ references across Android, Spin, Web, Python, and manifests.*
+
+### Step 3: Commit, Push & Open Pull Request
+```bash
+git add VERSION_MANIFEST.json mecris-go-project/app/build.gradle.kts boris-fiona-walker/spin.toml mecris-go-spin/sync-service/spin.toml pyproject.toml web/package.json ROADMAP.md
+git commit -m "chore(release): bump version to {VERSION} + VC={VERSION_CODE}"
+git push origin release/v{VERSION}
+gh pr create --title "chore(release): release v{VERSION}" --body "Release preparation for v{VERSION} (VC={VERSION_CODE})." --base main
+```
+
+### Step 4: Verify CI & Merge PR to Main
+- Wait for mandatory CI checks on the PR to pass (`gh pr checks {PR_NUMBER}`).
+- Merge PR cleanly to `main` via squash or merge commit.
+
+### Step 5: Tag and Push Release on Main (Wait for Main CI First!)
+```bash
+git checkout main
+git pull origin main
+
+# Verify CI on main is 100% green before tagging:
+gh run list --branch main -L 1
+
+# Create and push the release tag with 'v' prefix:
+git tag v{VERSION}
+git push origin v{VERSION}
+```
+- GitHub Actions (`release.yml`) will build release artifacts, upload packages, and draft/publish the GitHub Release.

--- a/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
@@ -285,14 +285,19 @@ fun MecrisDashboard(
 
     LaunchedEffect(auth) {
         auth.errorEvents.collect { error ->
-            val message = "${error.errorCode}: ${error.message}"
-            val result = snackbarHostState.showSnackbar(
-                message = message,
-                actionLabel = "OPEN AUTH",
-                duration = SnackbarDuration.Indefinite
-            )
-            if (result == SnackbarResult.ActionPerformed) {
-                auth.authenticateWithPasskey(authResultLauncher)
+            if (error.isPermanent) {
+                val message = "${error.errorCode}: ${error.message}"
+                val result = snackbarHostState.showSnackbar(
+                    message = message,
+                    actionLabel = "OPEN AUTH",
+                    duration = SnackbarDuration.Indefinite
+                )
+                if (result == SnackbarResult.ActionPerformed) {
+                    auth.authenticateWithPasskey(authResultLauncher)
+                }
+            } else {
+                Log.d("MainActivity", "Transient auth notice: ${error.errorCode} - ${error.message}")
+                syncStatus = "Offline (PocketID reconnecting)"
             }
         }
     }

--- a/mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthError.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthError.kt
@@ -90,6 +90,25 @@ sealed interface AuthError {
 
     companion object {
         fun fromException(e: Exception, context: Context? = null): AuthError {
+            // Check AppAuth structured exception types first
+            if (e is net.openid.appauth.AuthorizationException) {
+                if (e.type == net.openid.appauth.AuthorizationException.TYPE_GENERAL_ERROR &&
+                    (e.code == net.openid.appauth.AuthorizationException.GeneralErrors.NETWORK_ERROR.code ||
+                     e.code == net.openid.appauth.AuthorizationException.GeneralErrors.SERVER_ERROR.code)
+                ) {
+                    return NetworkUnreachable(detail = e.errorDescription ?: e.message ?: "AppAuth Network/Server error")
+                }
+                if (e.type == net.openid.appauth.AuthorizationException.TYPE_OAUTH_TOKEN_ERROR) {
+                    val desc = (e.errorDescription ?: e.error ?: "").lowercase()
+                    if (desc.contains("invalid_grant") || desc.contains("revoked")) {
+                        return TokenRevoked(detail = e.errorDescription ?: e.message)
+                    }
+                    if (desc.contains("expired")) {
+                        return TokenExpired(detail = e.errorDescription ?: e.message)
+                    }
+                }
+            }
+
             val message = e.message ?: e.javaClass.simpleName
             val lower = message.lowercase()
 
@@ -110,7 +129,8 @@ sealed interface AuthError {
 
                 // Network unreachable
                 lower.contains("network") || lower.contains("connection") || lower.contains("timeout") ||
-                lower.contains("unreachable") || lower.contains("dns") || lower.contains("resolve") ->
+                lower.contains("unreachable") || lower.contains("dns") || lower.contains("resolve") ||
+                lower.contains("authorizationexception") ->
                     NetworkUnreachable(detail = message)
 
                 // OIDC endpoint HTTP errors


### PR DESCRIPTION
## Summary
- **Structured AppAuth Error Classification**: In `AuthError.kt`, inspect typed `AuthorizationException` properties (`TYPE_GENERAL_ERROR`, `GeneralErrors.NETWORK_ERROR`, `GeneralErrors.SERVER_ERROR`) to accurately classify socket timeouts, DNS lapses, and transient network hops as `NetworkUnreachable` (`isPermanent = false`) instead of falling back to `UNKNOWN`.
- **Calm UI Status (No Modal Harassment)**: In `MainActivity.kt`, the indefinite `OPEN AUTH` modal snackbar is now strictly restricted to permanent errors (`error.isPermanent == true` such as passkey revocation or 30-day sliding TTL expiry). Transient reconnects quietly update the dashboard sync status to `Offline (PocketID reconnecting)` without interrupting the user.
- **PocketID Chore Skill**: Authored `/chore-pocketid-inventory` in `.github/skills` and `.claude/skills` for guided NAS/OIDC endpoint verification.
- **Release Workflow Skill**: Added `/release-workflow` documenting standard release tagging and verification procedures.

## Verification
- Unit test suite `./gradlew testDebugUnitTest` passed in 834ms.
- Full debug build `./gradlew assembleDebug` built cleanly in 24s.