### PR TITLE
chore(release): Mecris 0.0.1-rc.6 — PocketID Refresh Token Win & Calm Auth UX

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Mission**: Transform Mecris from reactive MCP server to autonomous cognitive agent with rich contextual awareness
 
 ## 📊 Current Status
-- **Version**: v0.0.1-rc.5 (2026-08-15) ✅
+- **Version**: v0.0.1-rc.6 (2026-08-15) ✅
 - **Budget**: $20.88 remaining (Expires 2026-04-14)
 - **Foundation**: Production-ready MCP server with Beeminder, Budget, and Twilio integrations ✅
 - **Progress**: Autonomous nagging implemented via MCP Scheduler and Android Heartbeat ✅

--- a/VERSION_MANIFEST.json
+++ b/VERSION_MANIFEST.json
@@ -1,11 +1,11 @@
 {
   "suite_name": "Mecris Personal Accountability Suite",
   "release_date": "2026-08-15",
-  "total_version": "0.0.1-rc.5",
+  "total_version": "0.0.1-rc.6",
   "components": {
     "android_app": {
       "name": "Mecris-Go Android",
-      "version": "0.0.1-rc.5",
+      "version": "0.0.1-rc.6",
       "features": [
         "OIDC Submarine Mode Fixes",
         "WorkManager Heartbeat",
@@ -17,7 +17,7 @@
     },
     "spin_backend": {
       "name": "Mecris-Go Sync Service (Spin)",
-      "version": "0.0.1-rc.5",
+      "version": "0.0.1-rc.6",
       "features": [
         "Arabic Skip Counter",
         "Multi-Component Layout",
@@ -29,7 +29,7 @@
     },
     "python_mcp": {
       "name": "Mecris MCP Server",
-      "version": "0.0.1-rc.5",
+      "version": "0.0.1-rc.6",
       "features": [
         "Hardened Authentication",
         "Enriched System Pulse",
@@ -40,7 +40,7 @@
     },
     "neon_infrastructure": {
       "name": "Neon PostgreSQL Cloud",
-      "version": "0.0.1-rc.5",
+      "version": "0.0.1-rc.6",
       "features": [
         "Ghost Presence Table",
         "Message Log with Compliance Status",

--- a/blog/2026-08-15-weekend-chores-and-the-lost-arms.md
+++ b/blog/2026-08-15-weekend-chores-and-the-lost-arms.md
@@ -130,13 +130,28 @@ When play-testing the Web dashboard live, we uncovered a fascinating distributed
 
 ---
 
-## 7. Next Step: Sunday Lookback & Continuous Streak
+## 7. The PocketID Breakthrough & Calm Auth UX
 
-All skills have been authored in both [`.github/skills/`](file:///Users/yebyen/w/mecris/.github/skills/) and [`.claude/skills/`](file:///Users/yebyen/w/mecris/.claude/skills/):
+During live field testing on Android, we encountered a classic mobile OIDC edge case: momentary Wi-Fi/DNS transitions were bubbling up as raw `UNKNOWN: AuthorizationException` modal snackbars, demanding unnecessary passkey logins even when the session was healthy.
+
+We tackled this with a comprehensive architectural overhaul:
+1. **Typed AppAuth Error Classification**: Updated `AuthError.kt` to inspect `AuthorizationException.TYPE_GENERAL_ERROR` and `GeneralErrors.NETWORK_ERROR`, correctly classifying transient transport hiccups as `NetworkUnreachable` (`isPermanent = false`).
+2. **Calm UI De-escalation**: In `MainActivity.kt`, modal "OPEN AUTH" snackbars are now strictly reserved for true permanent revocation (`invalid_grant` / passkey revoked). Transient drops quietly update the status to `"Offline (PocketID reconnecting)"` while background exponential backoff handles reconnection.
+3. **The 30-Day Refresh Token Secured (🎉)**: Under the fresh OIDC scope negotiation (`openid`, `profile`, `email`, `offline_access`), PocketID presented full user consent and successfully minted a hardware-encrypted 30-day sliding refresh token.
+
+We codified this into [`/chore-pocketid-inventory`](file:///Users/yebyen/w/mecris/.github/skills/chore-pocketid-inventory/SKILL.md) and tagged **`v0.0.1-rc.6` (versionCode 30)** for our weekend soak!
+
+---
+
+## 8. Next Step: Sunday Lookback & Continuous Streak
+
+Our weekend chore toolkit now spans 6 specialized inspection arms:
 - `/chore-web-inventory`
 - `/chore-android-inventory`
 - `/chore-cli-inventory`
 - `/chore-twilio-inventory`
+- `/chore-moon-clock-inventory`
+- `/chore-pocketid-inventory`
 - `/chore-weekend-master`
 
-Tomorrow, on Sunday morning, we run the second pass with `/chore-weekend-master`, verify the continuous streak, and generate the week's first completed chore flair!
+Tomorrow, on Sunday morning, we run the second pass with `/chore-weekend-master`, verify the continuous streak across all arms, and generate the week's first completed chore flair!

--- a/boris-fiona-walker/spin.toml
+++ b/boris-fiona-walker/spin.toml
@@ -2,7 +2,7 @@ spin_manifest_version = 2
 
 [application]
 name = "boris-fiona-walker"
-version = "0.0.1-rc.5"
+version = "0.0.1-rc.6"
 authors = ["Kingdon Barrett <kingdon@urmanac.com>"]
 description = "WASM walk reminder system for Boris and Fiona"
 

--- a/mecris-go-project/app/build.gradle.kts
+++ b/mecris-go-project/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.mecris.go"
         minSdk = 31
         targetSdk = 37
-        versionCode = 29
-        versionName = "0.0.1-rc.5"
+        versionCode = 30
+        versionName = "0.0.1-rc.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/mecris-go-spin/sync-service/spin.toml
+++ b/mecris-go-spin/sync-service/spin.toml
@@ -4,7 +4,7 @@ spin_manifest_version = 2
 
 [application]
 name = "mecris-sync-v2"
-version = "0.0.1-rc.5"
+version = "0.0.1-rc.6"
 authors = ["Kingdon B <kingdon@urmanac.com>"]
 description = ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mecris"
-version = "0.0.1-rc.5"
+version = "0.0.1-rc.6"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.0.1-rc.5",
+  "version": "0.0.1-rc.6",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
This release candidate finalizes the **PocketID Calm Auth UX**, secures the 30-day sliding refresh token under full OIDC scope negotiation, updates architectural documentation, and bumps the ecosystem version to `0.0.1-rc.6` (versionCode `30`).

### 1. The PocketID Breakthrough & Calm UX
- **Typed AppAuth Error Handling**: In `AuthError.kt`, `AuthorizationException` properties (`TYPE_GENERAL_ERROR`, `GeneralErrors.NETWORK_ERROR`) now cleanly map socket/DNS hiccups to `NetworkUnreachable` (`isPermanent = false`).
- **Calm Status Indicator**: `MainActivity.kt` restricts modal `OPEN AUTH` snackbars to permanent revocations (`isPermanent = true`), letting transient drops show a calm `Offline (PocketID reconnecting)` notice.
- **30-Day Refresh Token Secured**: Verified full OIDC user consent and 30-day sliding refresh token establishment in hardware-backed `EncryptedSharedPreferences`.

### 2. Documentation & Skills
- Authored `/chore-pocketid-inventory` in `.github/skills` and `.claude/skills`.
- Authored `/release-workflow` following `docs/RELEASE_PROCESS.md`.
- Updated `blog/2026-08-15-weekend-chores-and-the-lost-arms.md` with Section 7.

### 3. Version Bump
- Synchronized all 15+ version locations across Android, Spin, Web, Python MCP, and manifests to `0.0.1-rc.6` (versionCode `30`).