### PR TITLE
fix(auth): instantiate fresh AuthState to clear AppAuth error lock

### DIFF
--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -34,7 +34,7 @@ make bump-version VERSION={VERSION} VC={VERSION_CODE}
 
 ### Step 3: Commit, Push & Open Pull Request
 ```bash
-git add VERSION_MANIFEST.json mecris-go-project/app/build.gradle.kts boris-fiona-walker/spin.toml mecris-go-spin/sync-service/spin.toml pyproject.toml web/package.json ROADMAP.md
+git add VERSION_MANIFEST.json mecris-go-project/app/build.gradle.kts boris-fiona-walker/spin.toml mecris-go-spin/sync-service/spin.toml pyproject.toml uv.lock web/package.json ROADMAP.md
 git commit -m "chore(release): bump version to {VERSION} + VC={VERSION_CODE}"
 git push origin release/v{VERSION}
 gh pr create --title "chore(release): release v{VERSION}" --body "Release preparation for v{VERSION} (VC={VERSION_CODE})." --base main

--- a/.github/skills/release-workflow/SKILL.md
+++ b/.github/skills/release-workflow/SKILL.md
@@ -34,7 +34,7 @@ make bump-version VERSION={VERSION} VC={VERSION_CODE}
 
 ### Step 3: Commit, Push & Open Pull Request
 ```bash
-git add VERSION_MANIFEST.json mecris-go-project/app/build.gradle.kts boris-fiona-walker/spin.toml mecris-go-spin/sync-service/spin.toml pyproject.toml web/package.json ROADMAP.md
+git add VERSION_MANIFEST.json mecris-go-project/app/build.gradle.kts boris-fiona-walker/spin.toml mecris-go-spin/sync-service/spin.toml pyproject.toml uv.lock web/package.json ROADMAP.md
 git commit -m "chore(release): bump version to {VERSION} + VC={VERSION_CODE}"
 git push origin release/v{VERSION}
 gh pr create --title "chore(release): release v{VERSION}" --body "Release preparation for v{VERSION} (VC={VERSION_CODE})." --base main

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Mission**: Transform Mecris from reactive MCP server to autonomous cognitive agent with rich contextual awareness
 
 ## 📊 Current Status
-- **Version**: v0.0.1 (2026-08-16) ✅
+- **Version**: v0.0.2 (2026-08-20) ✅
 - **Budget**: $20.88 remaining (Expires 2026-04-14)
 - **Foundation**: Production-ready MCP server with Beeminder, Budget, and Twilio integrations ✅
 - **Progress**: Autonomous nagging implemented via MCP Scheduler and Android Heartbeat ✅

--- a/VERSION_MANIFEST.json
+++ b/VERSION_MANIFEST.json
@@ -1,11 +1,11 @@
 {
   "suite_name": "Mecris Personal Accountability Suite",
-  "release_date": "2026-08-16",
-  "total_version": "0.0.1",
+  "release_date": "2026-08-20",
+  "total_version": "0.0.2",
   "components": {
     "android_app": {
       "name": "Mecris-Go Android",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "features": [
         "OIDC Submarine Mode Fixes",
         "WorkManager Heartbeat",
@@ -17,7 +17,7 @@
     },
     "spin_backend": {
       "name": "Mecris-Go Sync Service (Spin)",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "features": [
         "Arabic Skip Counter",
         "Multi-Component Layout",
@@ -29,7 +29,7 @@
     },
     "python_mcp": {
       "name": "Mecris MCP Server",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "features": [
         "Hardened Authentication",
         "Enriched System Pulse",
@@ -40,7 +40,7 @@
     },
     "neon_infrastructure": {
       "name": "Neon PostgreSQL Cloud",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "features": [
         "Ghost Presence Table",
         "Message Log with Compliance Status",

--- a/boris-fiona-walker/spin.toml
+++ b/boris-fiona-walker/spin.toml
@@ -2,7 +2,7 @@ spin_manifest_version = 2
 
 [application]
 name = "boris-fiona-walker"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Kingdon Barrett <kingdon@urmanac.com>"]
 description = "WASM walk reminder system for Boris and Fiona"
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -57,6 +57,7 @@ This updates:
 - `boris-fiona-walker/spin.toml` (Spin/WASM)
 - `mecris-go-spin/sync-service/spin.toml` (Spin/WASM)
 - `pyproject.toml` (Python)
+- `uv.lock` (Auto-synchronized via `uv lock`)
 - `web/package.json` (Web)
 - `ROADMAP.md` (version label + date)
 
@@ -70,6 +71,7 @@ git add VERSION_MANIFEST.json \
         boris-fiona-walker/spin.toml \
         mecris-go-spin/sync-service/spin.toml \
         pyproject.toml \
+        uv.lock \
         web/package.json \
         ROADMAP.md \
         docs/RELEASE_PROCESS.md
@@ -159,6 +161,7 @@ make bump-version VERSION=0.0.1-rc.5 VC=29
 |------|-----------|-------|
 | `VERSION_MANIFEST.json` | Master manifest | All components listed |
 | `pyproject.toml` | Python package | `version = "..."` |
+| `uv.lock` | Python lockfile | Auto-locked via `uv lock` |
 | `mecris-go-project/app/build.gradle.kts` | Android | `versionName`, `versionCode` |
 | `mecris-go-spin/sync-service/spin.toml` | Spin sync-service | `version = "..."` |
 | `boris-fiona-walker/spin.toml` | Spin walker | `version = "..."` |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -37,18 +37,23 @@ make test-rust
 
 All tests must pass. CI must be green on `main`.
 
-### 2. Create Release Branch & Bump Version
+### 2. Bump Version on PR / Release Branch
 
-Create a release branch from `main`:
+You can release directly from an active PR branch (to avoid redundant CI runs) or create a dedicated release branch:
+
 ```bash
+# Option A: Direct from active feature/fix PR branch (Recommended for faster turnaround)
+# Simply apply the bump directly on the working branch before merging.
+
+# Option B: Dedicated release branch from main
 git checkout main && git pull origin main
-git checkout -b release/v0.0.1-rc.4
+git checkout -b release/v0.0.2
 ```
 
 Use the official version bump script (updates 15+ version strings across the repo, including Android `versionCode` via `VC=nn`):
 
 ```bash
-make bump-version VERSION=0.0.1-rc.4 VC=28
+make bump-version VERSION=0.0.2 VC=33
 ```
 
 This updates:
@@ -61,9 +66,9 @@ This updates:
 - `web/package.json` (Web)
 - `ROADMAP.md` (version label + date)
 
-### 3. Commit, Push Branch & Open PR (Branch Protection)
+### 3. Commit, Push & Run CI (1st CI Run: Before Merge)
 
-Because `main` is protected with mandatory CI checks, releases must go through a pull request:
+Commit and push the version bump to the PR branch:
 
 ```bash
 git add VERSION_MANIFEST.json \
@@ -76,12 +81,11 @@ git add VERSION_MANIFEST.json \
         ROADMAP.md \
         docs/RELEASE_PROCESS.md
 
-git commit -m "chore(release): bump version to 0.0.1-rc.4 + VC=28"
-git push origin release/v0.0.1-rc.4
-
-# Open PR using GitHub CLI
-gh pr create --title "chore(release): release v0.0.1-rc.4" --body "Release preparation for v0.0.1-rc.4 (VC=28)." --base main
+git commit -m "chore(release): bump version to 0.0.2 + VC=33"
+git push origin <branch-name>
 ```
+
+Wait for CI to run and pass on the PR. Mandatory checks run automatically.
 
 ### 4. Merge PR to Main
 

--- a/mecris-go-project/app/build.gradle.kts
+++ b/mecris-go-project/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.mecris.go"
         minSdk = 31
         targetSdk = 37
-        versionCode = 32
-        versionName = "0.0.1"
+        versionCode = 33
+        versionName = "0.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         

--- a/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
@@ -285,6 +285,10 @@ fun MecrisDashboard(
 
     LaunchedEffect(auth) {
         auth.errorEvents.collect { error ->
+            if (auth.authState.value is AuthState.Authenticated) {
+                // Ignore errors if we have already re-established an Authenticated session
+                return@collect
+            }
             if (error.isPermanent) {
                 val message = "${error.errorCode}: ${error.message}"
                 val result = snackbarHostState.showSnackbar(
@@ -305,6 +309,10 @@ fun MecrisDashboard(
     LaunchedEffect(authState) {
         if (authState is AuthState.Authenticated) {
             snackbarHostState.currentSnackbarData?.dismiss()
+            (context as? ComponentActivity)?.let { act ->
+                act.intent?.removeExtra("trigger_auth")
+                act.intent?.removeExtra("prefill_email")
+            }
         }
     }
 
@@ -312,8 +320,10 @@ fun MecrisDashboard(
     LaunchedEffect(activity?.intent) {
         val intent = activity?.intent
         if (intent?.getBooleanExtra("trigger_auth", false) == true) {
-            val email = intent.getStringExtra("prefill_email")
-            auth.authenticateWithPasskey(authResultLauncher, emailHint = email)
+            if (auth.authState.value !is AuthState.Authenticated) {
+                val email = intent.getStringExtra("prefill_email")
+                auth.authenticateWithPasskey(authResultLauncher, emailHint = email)
+            }
             // Consume the intent so we don't trigger it again on config changes
             intent.removeExtra("trigger_auth")
             intent.removeExtra("prefill_email")

--- a/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
@@ -95,7 +95,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         
         val errorReporter = AuthErrorReporter(this)
-        pocketIdAuth = PocketIdAuthRepository(
+        pocketIdAuth = PocketIdAuthRepository.getInstance(
             context = this,
             errorReporter = errorReporter
         )

--- a/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/MainActivity.kt
@@ -209,9 +209,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        if (::pocketIdAuth.isInitialized) {
-            pocketIdAuth.dispose()
-        }
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -285,10 +282,6 @@ fun MecrisDashboard(
 
     LaunchedEffect(auth) {
         auth.errorEvents.collect { error ->
-            if (auth.authState.value is AuthState.Authenticated) {
-                // Ignore errors if we have already re-established an Authenticated session
-                return@collect
-            }
             if (error.isPermanent) {
                 val message = "${error.errorCode}: ${error.message}"
                 val result = snackbarHostState.showSnackbar(
@@ -300,8 +293,10 @@ fun MecrisDashboard(
                     auth.authenticateWithPasskey(authResultLauncher)
                 }
             } else {
-                Log.d("MainActivity", "Transient auth notice: ${error.errorCode} - ${error.message}")
-                syncStatus = "Offline (PocketID reconnecting)"
+                if (auth.authState.value !is AuthState.Authenticated) {
+                    Log.d("MainActivity", "Transient auth notice: ${error.errorCode} - ${error.message}")
+                    syncStatus = "Offline (PocketID reconnecting)"
+                }
             }
         }
     }
@@ -312,6 +307,16 @@ fun MecrisDashboard(
             (context as? ComponentActivity)?.let { act ->
                 act.intent?.removeExtra("trigger_auth")
                 act.intent?.removeExtra("prefill_email")
+            }
+        } else if (authState is AuthState.Error && (authState as AuthState.Error).isPermanent) {
+            val err = authState as AuthState.Error
+            val result = snackbarHostState.showSnackbar(
+                message = "${err.message}",
+                actionLabel = "OPEN AUTH",
+                duration = SnackbarDuration.Indefinite
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                auth.authenticateWithPasskey(authResultLauncher)
             }
         }
     }

--- a/mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthError.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthError.kt
@@ -114,12 +114,10 @@ sealed interface AuthError {
                 }
                 if (e.type == net.openid.appauth.AuthorizationException.TYPE_OAUTH_TOKEN_ERROR) {
                     val desc = (e.errorDescription ?: e.error ?: "").lowercase()
-                    if (desc.contains("invalid_grant") || desc.contains("revoked")) {
-                        return TokenRevoked(detail = e.errorDescription ?: e.message)
-                    }
                     if (desc.contains("expired")) {
                         return TokenExpired(detail = e.errorDescription ?: e.message)
                     }
+                    return TokenRevoked(detail = e.errorDescription ?: e.error ?: e.message)
                 }
             }
 
@@ -147,8 +145,7 @@ sealed interface AuthError {
 
                 // Network unreachable
                 lower.contains("network") || lower.contains("connection") || lower.contains("timeout") ||
-                lower.contains("unreachable") || lower.contains("dns") || lower.contains("resolve") ||
-                lower.contains("authorizationexception") ->
+                lower.contains("unreachable") || lower.contains("dns") || lower.contains("resolve") ->
                     NetworkUnreachable(detail = message)
 
                 // OIDC endpoint HTTP errors

--- a/mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthViewModel.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthViewModel.kt
@@ -166,6 +166,5 @@ class AuthViewModel(application: Application) : AndroidViewModel(application) {
     override fun onCleared() {
         super.onCleared()
         cancelAutoRetry()
-        repository.dispose()
     }
 }

--- a/mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthViewModel.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/auth/AuthViewModel.kt
@@ -25,7 +25,7 @@ class AuthViewModel(application: Application) : AndroidViewModel(application) {
 
     // Repository will be injected via Hilt/Koin in production; for now we create it
     private val repository by lazy {
-        PocketIdAuthRepository(
+        PocketIdAuthRepository.getInstance(
             context = getApplication()
         )
     }

--- a/mecris-go-project/app/src/main/java/com/mecris/go/auth/PocketIdAuthRepository.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/auth/PocketIdAuthRepository.kt
@@ -156,6 +156,7 @@ class PocketIdAuthRepository(
                     val jwt = internalAuthState.accessToken ?: internalAuthState.idToken
                     if (jwt != null) {
                         _authState.value = AuthState.Authenticated(jwt)
+                        errorReporter?.clearNotification()
                     } else {
                         // Has refresh token but no access token — trigger silent refresh
                         refreshAccessToken { _ -> }
@@ -277,6 +278,7 @@ class PocketIdAuthRepository(
                         }
                         saveLastKnownEmail(tokenResponse.idToken?.let { parseEmailFromIdToken(it) } ?: "")
                         _authState.value = AuthState.Authenticated(jwt)
+                        errorReporter?.clearNotification()
                     } else {
                         val error = AuthError.Unknown(message = "No access token received")
                         reportError(error)
@@ -333,6 +335,7 @@ class PocketIdAuthRepository(
                     saveAuthState()
                     saveRefreshTokenTimestamp()
                     _authState.value = AuthState.Authenticated(accessToken)
+                    errorReporter?.clearNotification()
                 }
                 callback(accessToken)
             }

--- a/mecris-go-project/app/src/main/java/com/mecris/go/auth/PocketIdAuthRepository.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/auth/PocketIdAuthRepository.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
 import net.openid.appauth.AuthState as AppAuthAuthState
 import net.openid.appauth.AuthorizationException
@@ -154,11 +155,11 @@ class PocketIdAuthRepository(
                 internalAuthState = AppAuthAuthState.jsonDeserialize(json)
                 if (internalAuthState.isAuthorized) {
                     val jwt = internalAuthState.accessToken ?: internalAuthState.idToken
-                    if (jwt != null) {
+                    if (jwt != null && !internalAuthState.needsTokenRefresh) {
                         _authState.value = AuthState.Authenticated(jwt)
                         errorReporter?.clearNotification()
                     } else {
-                        // Has refresh token but no access token — trigger silent refresh
+                        // Has refresh token or expired access token — trigger silent refresh
                         refreshAccessToken { _ -> }
                     }
                 }
@@ -322,12 +323,12 @@ class PocketIdAuthRepository(
             if (ex != null) {
                 android.util.Log.e("PocketIdAuth", "performActionWithFreshTokens error: ${ex.message}", ex)
                 val error = classifyTokenError(ex)
-                reportError(error)
                 if (error.isPermanent) {
                     _authState.value = AuthState.Error(error.message, isPermanent = true)
                 } else {
                     clearTransientException()
                 }
+                reportError(error)
                 callback(null)
             } else {
                 if (accessToken != null) {
@@ -342,23 +343,31 @@ class PocketIdAuthRepository(
         }
     }
 
-    /** Suspend version for coroutines. */
-    suspend fun getAccessTokenSuspend(): String? = refreshMutex.withLock {
-        return@withLock kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
-            getValidAccessToken { token ->
-                continuation.resume(token)
+    /** Suspend version for coroutines with timeout to prevent hanging UI/workers. */
+    suspend fun getAccessTokenSuspend(): String? = withTimeoutOrNull(15000L) {
+        refreshMutex.withLock {
+            kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
+                getValidAccessToken { token ->
+                    if (continuation.isActive) {
+                        continuation.resume(token)
+                    }
+                }
             }
         }
     }
 
     /** Forces an immediate token refresh. */
-    suspend fun forceTokenRefresh(): String? = refreshMutex.withLock {
-        return@withLock kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
-            // Force AppAuth to treat the current access token as expired
-            internalAuthState.setNeedsTokenRefresh(true)
+    suspend fun forceTokenRefresh(): String? = withTimeoutOrNull(15000L) {
+        refreshMutex.withLock {
+            kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
+                // Force AppAuth to treat the current access token as expired
+                internalAuthState.setNeedsTokenRefresh(true)
 
-            getValidAccessToken { token ->
-                continuation.resume(token)
+                getValidAccessToken { token ->
+                    if (continuation.isActive) {
+                        continuation.resume(token)
+                    }
+                }
             }
         }
     }
@@ -441,11 +450,11 @@ class PocketIdAuthRepository(
         internalAuthState.performActionWithFreshTokens(authService) { accessToken, _, ex ->
             if (ex != null) {
                 val error = classifyTokenError(ex)
-                reportError(error)
                 if (error.isPermanent) {
                     _authState.value = AuthState.Error(error.message, isPermanent = true)
                     stopBackgroundRefresh()
                 }
+                reportError(error)
                 callback(false)
             } else {
                 if (accessToken != null) {

--- a/mecris-go-project/app/src/main/java/com/mecris/go/auth/PocketIdAuthRepository.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/auth/PocketIdAuthRepository.kt
@@ -39,8 +39,8 @@ class PocketIdAuthRepository(
     private val context: Context,
     private val authService: AuthorizationService = AuthorizationService(context),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
-    private val errorReporter: AuthErrorReporter? = null,
-    private val errorDatabase: AuthErrorDatabase? = null
+    var errorReporter: AuthErrorReporter? = null,
+    var errorDatabase: AuthErrorDatabase? = null
 ) {
 
     // EncryptedSharedPreferences keys
@@ -100,6 +100,26 @@ class PocketIdAuthRepository(
         private const val REFRESH_TOKEN_TTL_DAYS = 30L
         // Proactive refresh at 80% TTL (24 days)
         private const val PROACTIVE_REFRESH_THRESHOLD_PERCENT = 0.8
+
+        @Volatile
+        private var INSTANCE: PocketIdAuthRepository? = null
+
+        fun getInstance(
+            context: Context,
+            errorReporter: AuthErrorReporter? = null,
+            errorDatabase: AuthErrorDatabase? = null
+        ): PocketIdAuthRepository {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: PocketIdAuthRepository(
+                    context.applicationContext,
+                    errorReporter = errorReporter,
+                    errorDatabase = errorDatabase
+                ).also { INSTANCE = it }
+            }.apply {
+                if (errorReporter != null) this.errorReporter = errorReporter
+                if (errorDatabase != null) this.errorDatabase = errorDatabase
+            }
+        }
     }
 
     init {
@@ -311,6 +331,7 @@ class PocketIdAuthRepository(
                 if (accessToken != null) {
                     android.util.Log.d("PocketIdAuth", "Fresh access token retrieved successfully.")
                     saveAuthState()
+                    saveRefreshTokenTimestamp()
                     _authState.value = AuthState.Authenticated(accessToken)
                 }
                 callback(accessToken)
@@ -396,7 +417,12 @@ class PocketIdAuthRepository(
     /** Calculates milliseconds until proactive refresh (80% of TTL). */
     private fun calculateTimeUntilProactiveRefresh(): Long {
         val issuedAt = prefs.getLong(KEY_REFRESH_TOKEN_ISSUED_AT, 0L)
-        if (issuedAt == 0L) return 0 // No timestamp, refresh immediately
+        if (issuedAt == 0L) {
+            saveRefreshTokenTimestamp()
+            val ttlDays = prefs.getLong(KEY_REFRESH_TOKEN_TTL_DAYS, REFRESH_TOKEN_TTL_DAYS)
+            val ttlMillis = Duration.ofDays(ttlDays).toMillis()
+            return (ttlMillis * PROACTIVE_REFRESH_THRESHOLD_PERCENT).toLong()
+        }
 
         val ttlDays = prefs.getLong(KEY_REFRESH_TOKEN_TTL_DAYS, REFRESH_TOKEN_TTL_DAYS)
         val ttlMillis = Duration.ofDays(ttlDays).toMillis()

--- a/mecris-go-project/app/src/main/java/com/mecris/go/auth/PocketIdAuthRepository.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/auth/PocketIdAuthRepository.kt
@@ -228,10 +228,11 @@ class PocketIdAuthRepository(
         val resp = AuthorizationResponse.fromIntent(intent)
         val ex = AuthorizationException.fromIntent(intent)
 
-        internalAuthState.update(resp, ex)
-        saveAuthState()
-
         if (resp != null) {
+            // Initialize fresh AuthState from response to clear any prior error lock
+            internalAuthState = AppAuthAuthState(resp, ex)
+            saveAuthState()
+
             // Exchange authorization code for tokens
             authService.performTokenRequest(resp.createTokenExchangeRequest()) { tokenResponse, tokenException ->
                 internalAuthState.update(tokenResponse, tokenException)
@@ -297,6 +298,7 @@ class PocketIdAuthRepository(
         clearTransientException()
         internalAuthState.performActionWithFreshTokens(authService) { accessToken, _, ex ->
             if (ex != null) {
+                android.util.Log.e("PocketIdAuth", "performActionWithFreshTokens error: ${ex.message}", ex)
                 val error = classifyTokenError(ex)
                 reportError(error)
                 if (error.isPermanent) {
@@ -307,6 +309,7 @@ class PocketIdAuthRepository(
                 callback(null)
             } else {
                 if (accessToken != null) {
+                    android.util.Log.d("PocketIdAuth", "Fresh access token retrieved successfully.")
                     saveAuthState()
                     _authState.value = AuthState.Authenticated(accessToken)
                 }

--- a/mecris-go-project/app/src/main/java/com/mecris/go/health/DelayedNagWorker.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/health/DelayedNagWorker.kt
@@ -19,7 +19,7 @@ class DelayedNagWorker(
     workerParams: WorkerParameters
 ) : CoroutineWorker(appContext, workerParams) {
 
-    private val pocketIdAuth = PocketIdAuthRepository(applicationContext)
+    private val pocketIdAuth = PocketIdAuthRepository.getInstance(applicationContext)
     private val syncApi = SyncServiceApi.create(com.mecris.go.BackendManager.getBaseUrl(applicationContext))
     private val prefs = applicationContext.getSharedPreferences("mecris_worker_state", Context.MODE_PRIVATE)
     private val profileManager = ProfilePreferencesManager(applicationContext)

--- a/mecris-go-project/app/src/main/java/com/mecris/go/health/DelayedNagWorker.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/health/DelayedNagWorker.kt
@@ -33,17 +33,24 @@ class DelayedNagWorker(
         val nagManager = NagNotificationManager(applicationContext, syncApi)
 
         try {
+            var status: com.mecris.go.sync.AggregateStatusResponseDto? = null
             if (token != null) {
-                // 1. RE-VERIFY: Fetch latest status from cloud
-                val statusResponse = syncApi.getAggregateStatus("Bearer $token")
-                if (statusResponse.isSuccessful) {
-                    val status = statusResponse.body()
-                    if (status != null) {
-                        // 2. PIVOT: Decide what to nag about based on fresh data
-                        val healthManager = HealthConnectManager(applicationContext)
-                        val summary = if (healthManager.hasForegroundPermissions()) healthManager.fetchRecentWalkData() else null
-                        val result = evaluateNagHierarchy(status, token, summary)
-                        if (result != null) {
+                try {
+                    val statusResponse = syncApi.getAggregateStatus("Bearer $token")
+                    if (statusResponse.isSuccessful) {
+                        status = statusResponse.body()
+                    }
+                } catch (e: java.io.IOException) {
+                    Log.d("DelayedNagWorker", "Cloud aggregate status unreachable (offline): ${e.message}")
+                }
+            }
+
+            if (status != null) {
+                // 2. PIVOT: Decide what to nag about based on fresh data
+                val healthManager = HealthConnectManager(applicationContext)
+                val summary = if (healthManager.hasForegroundPermissions()) healthManager.fetchRecentWalkData() else null
+                val result = evaluateNagHierarchy(status, token!!, summary)
+                if (result != null) {
                             val (title, message, prefKey, packageName, llmMessage) = result
                             
                             // Check cooldowns: 
@@ -86,8 +93,6 @@ class DelayedNagWorker(
                         } else {
                             Log.i("DelayedNagWorker", "All clear or suppressed. No nag needed.")
                         }
-                    }
-                }
             } else {
                 // 3. SOVEREIGN FALLBACK: Basic local walk check
                 val localHourFallback = java.time.LocalDateTime.now().hour

--- a/mecris-go-project/app/src/main/java/com/mecris/go/health/WalkHeuristicsWorker.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/health/WalkHeuristicsWorker.kt
@@ -69,6 +69,8 @@ class WalkHeuristicsWorker @JvmOverloads constructor(
                             if (!remindersResponse.isSuccessful) {
                                 Log.w("WalkHeuristicsWorker", "Reminders trigger returned: ${remindersResponse.code()}")
                             }
+                        } catch (e: java.io.IOException) {
+                            Log.d("WalkHeuristicsWorker", "Reminders trigger skipped (offline): ${e.message}")
                         } catch (e: Exception) {
                             Log.e("WalkHeuristicsWorker", "Reminders trigger failed: ${e.message}")
                         }
@@ -78,6 +80,8 @@ class WalkHeuristicsWorker @JvmOverloads constructor(
                     Log.w("WalkHeuristicsWorker", "Heartbeat failed with code: ${hbResponse.code()}")
                 }
             }
+        } catch (e: java.io.IOException) {
+            Log.d("WalkHeuristicsWorker", "Cooperative check skipped (offline): ${e.message}")
         } catch (e: Exception) {
             Log.e("WalkHeuristicsWorker", "Cooperative check failed: ${e.message}")
         }
@@ -133,6 +137,8 @@ class WalkHeuristicsWorker @JvmOverloads constructor(
                     }
                 }
             }
+        } catch (e: java.io.IOException) {
+            Log.d("WalkHeuristicsWorker", "Nag scheduling skipped (offline): ${e.message}")
         } catch (e: Exception) {
             Log.e("WalkHeuristicsWorker", "Nag scheduling failed: ${e.message}")
         }
@@ -184,6 +190,9 @@ class WalkHeuristicsWorker @JvmOverloads constructor(
             }
             
             return Result.success()
+        } catch (e: java.io.IOException) {
+            Log.d("WalkHeuristicsWorker", "Health data cloud sync skipped (offline): ${e.message}")
+            return Result.retry()
         } catch (e: Exception) {
             Log.e("WalkHeuristicsWorker", "Execution error: ${e.message}")
             return Result.retry()

--- a/mecris-go-project/app/src/main/java/com/mecris/go/health/WalkHeuristicsWorker.kt
+++ b/mecris-go-project/app/src/main/java/com/mecris/go/health/WalkHeuristicsWorker.kt
@@ -26,7 +26,7 @@ class WalkHeuristicsWorker @JvmOverloads constructor(
     private val injectedSyncApi: SyncServiceApi? = null
 ) : CoroutineWorker(appContext, workerParams) {
 
-    private val pocketIdAuth = injectedAuth ?: PocketIdAuthRepository(applicationContext)
+    private val pocketIdAuth = injectedAuth ?: PocketIdAuthRepository.getInstance(applicationContext)
     private val syncApi = injectedSyncApi ?: SyncServiceApi.create(com.mecris.go.BackendManager.getBaseUrl(applicationContext))
     
     private val prefs = applicationContext.getSharedPreferences("mecris_worker_state", Context.MODE_PRIVATE)

--- a/mecris-go-spin/sync-service/spin.toml
+++ b/mecris-go-spin/sync-service/spin.toml
@@ -4,7 +4,7 @@ spin_manifest_version = 2
 
 [application]
 name = "mecris-sync-v2"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Kingdon B <kingdon@urmanac.com>"]
 description = ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mecris"
-version = "0.0.1"
+version = "0.0.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import re
+import subprocess
 import sys
 import os
 from datetime import datetime
@@ -43,13 +44,20 @@ def bump_version(new_version, version_code=None):
             content = re.sub(r'version\s*=\s*".*?"', f'version = "{new_version}"', content)
             spin_toml.write_text(content)
 
-    # 4. Update pyproject.toml
+    # 4. Update pyproject.toml and uv.lock
     pyproject = root / "pyproject.toml"
     if pyproject.exists():
         print(f"Updating {pyproject}...")
         content = pyproject.read_text()
         content = re.sub(r'^version\s*=\s*".*?"', f'version = "{new_version}"', content, flags=re.MULTILINE)
         pyproject.write_text(content)
+
+        # Keep uv.lock in sync with pyproject.toml version
+        try:
+            print("Updating uv.lock via uv lock...")
+            subprocess.run(["uv", "lock"], cwd=root, check=True)
+        except Exception as e:
+            print(f"Warning: Failed to run uv lock: {e}")
 
     # 5. Update web/package.json
     web_pkg = root / "web/package.json"

--- a/session_log.md
+++ b/session_log.md
@@ -1,6 +1,6 @@
-# Session Log: AppAuth Sticky Error-Lock Resolution & Release Lockfile Parity
+# Session Log: PocketID Refresh Token Rotation & Singleton Repository Architecture
 
-**Date:** 2026-08-19  
+**Date:** 2026-08-20  
 **Branch:** `fix/appauth-state-reset` (PR #289)  
 **Primary Model:** Gemini 3.7 Flash  
 **Human:** yebyen  
@@ -9,8 +9,18 @@
 
 ## Summary
 
-1. **AppAuth Error-Lock Fixed**: Investigated live ADB logcat traces showing `W AppAuth: AuthState.update should not be called in an error state`. Fixed `PocketIdAuthRepository.kt` to instantiate a fresh `AppAuthAuthState(resp, ex)` on passkey authorization, wiping any previous sticky `invalid_grant` error-lock state.
-2. **`uv.lock` Release Parity Plan & Implementation**: Identified why `uv.lock` drifted during the `0.0.1` release (`bump_version.py` updated `pyproject.toml` without running `uv lock`). Automated `uv lock` in `scripts/bump_version.py` and updated `docs/RELEASE_PROCESS.md` and `/release-workflow` skills to include `uv.lock` in version definitions and git staging.
+1. **Root Cause Analysis (`invalid_grant` / Stale Refresh Token Replay)**:
+   - Investigated live background failure from `WalkHeuristicsWorker` returning `invalid_grant: The refresh token is malformed or not valid`.
+   - Identified that PocketID issues 1-hour access tokens (`expires_in = 3600`) alongside 30-day sliding refresh tokens, requiring periodic background refresh grants.
+   - Discovered that `PocketIdAuthRepository` was being instantiated separately across `MainActivity`, `AuthViewModel`, `WalkHeuristicsWorker`, and `DelayedNagWorker`. Because PocketID v2.13 rotates refresh tokens on each exchange (single-use), independent uncoordinated instances replayed revoked in-memory refresh tokens, causing PocketID to reject subsequent requests with `invalid_grant` and permanently lock out the session.
+2. **Process Singleton Pattern & State Synchronization**:
+   - Implemented thread-safe `PocketIdAuthRepository.getInstance(...)` singleton pattern across all activities, view models, and WorkManager background workers.
+   - Synchronized refresh token timestamp persistence across `getValidAccessToken()` and proactive background loops to ensure the sliding window metadata stays aligned.
+   - Fixed `calculateTimeUntilProactiveRefresh()` to prevent eager immediate token refresh triggers when `KEY_REFRESH_TOKEN_ISSUED_AT` is uninitialized.
+3. **AppAuth Error-Lock Fixed**:
+   - Resolved sticky error state in `PocketIdAuthRepository.kt` by instantiating fresh `AppAuthAuthState(resp, ex)` on passkey authorization.
+4. **`uv.lock` Release Parity**:
+   - Automated `uv lock` in `scripts/bump_version.py` and updated release workflow documentation.
 
 ---
 

--- a/session_log.md
+++ b/session_log.md
@@ -17,12 +17,17 @@
    - Implemented thread-safe `PocketIdAuthRepository.getInstance(...)` singleton pattern across all activities, view models, and WorkManager background workers.
    - Synchronized refresh token timestamp persistence across `getValidAccessToken()` and proactive background loops to ensure the sliding window metadata stays aligned.
    - Fixed `calculateTimeUntilProactiveRefresh()` to prevent eager immediate token refresh triggers when `KEY_REFRESH_TOKEN_ISSUED_AT` is uninitialized.
-3. **AppAuth Error-Lock Fixed**:
+3. **AppAuth Error-Lock & Service Disposal Fix**:
    - Resolved sticky error state in `PocketIdAuthRepository.kt` by instantiating fresh `AppAuthAuthState(resp, ex)` on passkey authorization.
+   - Resolved `Auth refresh failed: Service has been disposed and rendered inoperable` by removing `pocketIdAuth.dispose()` from `MainActivity.onDestroy()`, keeping the shared singleton's `AuthorizationService` alive across activity recreation lifecycles.
 4. **Auth Notification & Re-Auth UI Flow Hardening**:
-   - Fixed stale `OPEN AUTH` snackbar remaining visible after successful re-authentication by guarding `errorEvents` against active `Authenticated` state and dismissing snackbars/consuming `trigger_auth` extras on state transition.
-   - Cleared persistent `41001` auth error notification on successful token exchange, access token fetch, and cached auth load.
-5. **`uv.lock` Release Parity**:
+   - Fixed order of operations in `PocketIdAuthRepository.kt`: updated `_authState.value = AuthState.Error(...)` *before* broadcasting to `_errorEvents` so `MainActivity`'s collector never evaluates against stale `Authenticated` state and drops the re-auth snackbar.
+   - Added direct `LaunchedEffect(authState)` observation for permanent `AuthState.Error` transitions to ensure the `"OPEN AUTH"` snackbar is always displayed.
+   - Replaced false `lower.contains("authorizationexception")` transient network mapping in `AuthError.fromException` with exhaustive `TYPE_OAUTH_TOKEN_ERROR` handling.
+   - Added 15-second timeout on `getAccessTokenSuspend()` and `forceTokenRefresh()` to prevent unresponsive token endpoints from freezing UI or workers.
+5. **Live 24h Refresh Token Verification**:
+   - Verified live on-device refresh after 24h soak: access token refreshed silently without re-auth, health sync succeeded, and background workers scheduled normally.
+6. **`uv.lock` Release Parity**:
    - Automated `uv lock` in `scripts/bump_version.py` and updated release workflow documentation.
 
 ---

--- a/session_log.md
+++ b/session_log.md
@@ -19,7 +19,10 @@
    - Fixed `calculateTimeUntilProactiveRefresh()` to prevent eager immediate token refresh triggers when `KEY_REFRESH_TOKEN_ISSUED_AT` is uninitialized.
 3. **AppAuth Error-Lock Fixed**:
    - Resolved sticky error state in `PocketIdAuthRepository.kt` by instantiating fresh `AppAuthAuthState(resp, ex)` on passkey authorization.
-4. **`uv.lock` Release Parity**:
+4. **Auth Notification & Re-Auth UI Flow Hardening**:
+   - Fixed stale `OPEN AUTH` snackbar remaining visible after successful re-authentication by guarding `errorEvents` against active `Authenticated` state and dismissing snackbars/consuming `trigger_auth` extras on state transition.
+   - Cleared persistent `41001` auth error notification on successful token exchange, access token fetch, and cached auth load.
+5. **`uv.lock` Release Parity**:
    - Automated `uv lock` in `scripts/bump_version.py` and updated release workflow documentation.
 
 ---

--- a/session_log.md
+++ b/session_log.md
@@ -1,8 +1,24 @@
+# Session Log: AppAuth Sticky Error-Lock Resolution & Release Lockfile Parity
+
+**Date:** 2026-08-19  
+**Branch:** `fix/appauth-state-reset` (PR #289)  
+**Primary Model:** Gemini 3.7 Flash  
+**Human:** yebyen  
+
+---
+
+## Summary
+
+1. **AppAuth Error-Lock Fixed**: Investigated live ADB logcat traces showing `W AppAuth: AuthState.update should not be called in an error state`. Fixed `PocketIdAuthRepository.kt` to instantiate a fresh `AppAuthAuthState(resp, ex)` on passkey authorization, wiping any previous sticky `invalid_grant` error-lock state.
+2. **`uv.lock` Release Parity Plan & Implementation**: Identified why `uv.lock` drifted during the `0.0.1` release (`bump_version.py` updated `pyproject.toml` without running `uv lock`). Automated `uv lock` in `scripts/bump_version.py` and updated `docs/RELEASE_PROCESS.md` and `/release-workflow` skills to include `uv.lock` in version definitions and git staging.
+
+---
+
 # Session Log: Akamai API Restored — Android Sync Unblocked
 
-**Date:** 2026-07-30
-**Branch:** `main`
-**Primary Model:** nemotron-3-ultra-550b-a55b:free (via OpenRouter) + Pi coding agent
+**Date:** 2026-07-30  
+**Branch:** `main`  
+**Primary Model:** nemotron-3-ultra-550b-a55b:free (via OpenRouter) + Pi coding agent  
 **Human:** yebyen
 
 ---

--- a/uv.lock
+++ b/uv.lock
@@ -901,7 +901,7 @@ wheels = [
 
 [[package]]
 name = "mecris"
-version = "0.0.1"
+version = "0.0.2"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },

--- a/uv.lock
+++ b/uv.lock
@@ -901,7 +901,7 @@ wheels = [
 
 [[package]]
 name = "mecris"
-version = "0.0.1rc2"
+version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Fixes the sticky `invalid_grant` error-lock bug in AppAuth Android during token refresh.

### 🔬 Root Cause
When AppAuth encountered an OAuth error (e.g. `invalid_grant`), it stored `mAuthorizationException` in `AuthState`. Calling `internalAuthState.update(resp, ex)` on re-authentication updated the existing tainted instance rather than clearing the exception, causing AppAuth to remain permanently error-locked and refuse subsequent token refresh calls (`W AppAuth: AuthState.update should not be called in an error state`).

### 🔧 Fix
1. In `PocketIdAuthRepository.kt`, `handleAuthorizationResponse` now instantiates a fresh `AppAuthAuthState(resp, ex)` upon receiving a valid `AuthorizationResponse`.
2. Added debug logging in `getValidAccessToken` to track token refresh success and errors.
3. Updated `uv.lock` to sync package version `0.0.1`.